### PR TITLE
feat: build document management UI and API

### DIFF
--- a/node_modules/.pnpm-workspace-state-v1.json
+++ b/node_modules/.pnpm-workspace-state-v1.json
@@ -1,0 +1,25 @@
+{
+  "lastValidatedTimestamp": 1776141522212,
+  "projects": {},
+  "pnpmfiles": [],
+  "settings": {
+    "autoInstallPeers": true,
+    "dedupeDirectDeps": false,
+    "dedupeInjectedDeps": true,
+    "dedupePeerDependents": true,
+    "dev": true,
+    "excludeLinksFromLockfile": false,
+    "hoistPattern": [
+      "*"
+    ],
+    "hoistWorkspacePackages": true,
+    "injectWorkspacePackages": false,
+    "linkWorkspacePackages": false,
+    "nodeLinker": "isolated",
+    "optional": true,
+    "preferWorkspacePackages": false,
+    "production": true,
+    "publicHoistPattern": []
+  },
+  "filteredInstall": false
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
Closes #13

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
node_modules/.pnpm-workspace-state-v1.json | 25 +++++++++++++++++++++++++
 pnpm-lock.yaml                             |  9 +++++++++
 2 files changed, 34 insertions(+)
```

## Commits

- `03f1522 feat: build document management UI and API`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed