### PR TITLE
feat: add adversarial editing pass to revision pipeline

### DIFF
--- a/src/pipeline/__tests__/adversarial-edit.test.ts
+++ b/src/pipeline/__tests__/adversarial-edit.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCuts,
+  computeDistribution,
+  formatReport,
+  parseAdversarialResponse,
+} from "../adversarial-edit";
+import type { AdversarialEditResult, ProposedCut } from "../types";
+
+const SAMPLE_RESPONSE = `CUT 1
+TYPE: OVER-EXPLAIN
+SECTION: Introduction
+PASSAGE: """This section explains the basic concepts that any reader familiar with the topic would already know. It covers ground that was already established in the abstract."""
+REASON: Readers of this document already understand these basics.
+WORDS: 28
+
+CUT 2
+TYPE: REDUNDANT
+SECTION: Methods
+PASSAGE: """As mentioned earlier, the approach uses a transformer-based architecture. The transformer architecture, which we described in the introduction, forms the basis of our method."""
+REASON: This restates information from the introduction without adding anything new.
+WORDS: 31
+
+CUT 3
+TYPE: FAT
+SECTION: Results
+PASSAGE: """It is important to note that the results clearly demonstrate"""
+REASON: Filler phrase that adds no meaning.
+WORDS: 10
+
+CUT 4
+TYPE: TELL
+SECTION: Discussion
+PASSAGE: """The results are impressive and show great promise for the field."""
+REASON: Assertion without evidence or specific data to support it.
+WORDS: 12
+
+CUT 5
+TYPE: STRUCTURAL
+SECTION: Background
+PASSAGE: """Before we proceed to the next section, let us briefly summarize what we have covered so far in this paper."""
+REASON: Unnecessary transition that interrupts flow.
+WORDS: 22
+
+CUT 6
+TYPE: GENERIC
+SECTION: Conclusion
+PASSAGE: """Future work will explore additional applications and improvements to the proposed method."""
+REASON: Could appear in any paper; contains no specific plans.
+WORDS: 13`;
+
+describe("parseAdversarialResponse", () => {
+  it("parses all cuts from a well-formed response", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts).toHaveLength(6);
+  });
+
+  it("extracts cut types correctly", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    const types = cuts.map((c) => c.type);
+    expect(types).toEqual([
+      "OVER-EXPLAIN",
+      "REDUNDANT",
+      "FAT",
+      "TELL",
+      "STRUCTURAL",
+      "GENERIC",
+    ]);
+  });
+
+  it("extracts passages correctly", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts[2].passage).toBe(
+      "It is important to note that the results clearly demonstrate",
+    );
+  });
+
+  it("extracts sections correctly", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts[0].section).toBe("Introduction");
+    expect(cuts[1].section).toBe("Methods");
+  });
+
+  it("extracts word counts", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts[2].wordCount).toBe(10);
+    expect(cuts[3].wordCount).toBe(12);
+  });
+
+  it("extracts reasons", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts[0].reason).toBe(
+      "Readers of this document already understand these basics.",
+    );
+  });
+
+  it("sets all cuts to pending status", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    expect(cuts.every((c) => c.status === "pending")).toBe(true);
+  });
+
+  it("assigns unique IDs to each cut", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    const ids = new Set(cuts.map((c) => c.id));
+    expect(ids.size).toBe(cuts.length);
+  });
+
+  it("handles empty response", () => {
+    expect(parseAdversarialResponse("")).toEqual([]);
+  });
+
+  it("skips malformed cut blocks", () => {
+    const partial = `CUT 1
+TYPE: OVER-EXPLAIN
+SECTION: Intro
+PASSAGE: """Some text here"""
+REASON: Good reason
+WORDS: 3
+
+CUT 2
+This block is malformed and has no proper fields`;
+
+    const cuts = parseAdversarialResponse(partial);
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0].type).toBe("OVER-EXPLAIN");
+  });
+
+  it("skips cuts with invalid types", () => {
+    const badType = `CUT 1
+TYPE: INVALID_TYPE
+SECTION: Intro
+PASSAGE: """Some text"""
+REASON: A reason
+WORDS: 2`;
+
+    const cuts = parseAdversarialResponse(badType);
+    expect(cuts).toHaveLength(0);
+  });
+
+  it("computes word count from passage when WORDS field is missing", () => {
+    const noWords = `CUT 1
+TYPE: FAT
+SECTION: Intro
+PASSAGE: """one two three four five"""
+REASON: Too many words`;
+
+    const cuts = parseAdversarialResponse(noWords);
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0].wordCount).toBe(5);
+  });
+});
+
+describe("computeDistribution", () => {
+  it("counts each cut type", () => {
+    const cuts = parseAdversarialResponse(SAMPLE_RESPONSE);
+    const dist = computeDistribution(cuts);
+    expect(dist["OVER-EXPLAIN"]).toBe(1);
+    expect(dist["REDUNDANT"]).toBe(1);
+    expect(dist["FAT"]).toBe(1);
+    expect(dist["TELL"]).toBe(1);
+    expect(dist["STRUCTURAL"]).toBe(1);
+    expect(dist["GENERIC"]).toBe(1);
+  });
+
+  it("handles empty cuts list", () => {
+    const dist = computeDistribution([]);
+    expect(dist["OVER-EXPLAIN"]).toBe(0);
+    expect(dist["REDUNDANT"]).toBe(0);
+  });
+
+  it("handles multiple cuts of same type", () => {
+    const cuts: ProposedCut[] = [
+      makeCut("OVER-EXPLAIN"),
+      makeCut("OVER-EXPLAIN"),
+      makeCut("REDUNDANT"),
+    ];
+    const dist = computeDistribution(cuts);
+    expect(dist["OVER-EXPLAIN"]).toBe(2);
+    expect(dist["REDUNDANT"]).toBe(1);
+    expect(dist["FAT"]).toBe(0);
+  });
+});
+
+describe("applyCuts", () => {
+  const document = `# Introduction
+
+This is the introduction with important content.
+
+It is important to note that we should proceed carefully.
+
+# Methods
+
+The methods section describes our approach.`;
+
+  it("removes accepted passages", () => {
+    const cuts: ProposedCut[] = [
+      {
+        ...makeCut("FAT"),
+        passage: "It is important to note that we should proceed carefully.",
+        status: "accepted",
+      },
+    ];
+
+    const result = applyCuts(document, cuts);
+    expect(result).not.toContain("It is important to note");
+    expect(result).toContain("This is the introduction");
+    expect(result).toContain("The methods section");
+  });
+
+  it("leaves rejected passages in place", () => {
+    const cuts: ProposedCut[] = [
+      {
+        ...makeCut("FAT"),
+        passage: "It is important to note that we should proceed carefully.",
+        status: "rejected",
+      },
+    ];
+
+    const result = applyCuts(document, cuts);
+    expect(result).toContain("It is important to note");
+  });
+
+  it("leaves pending passages in place", () => {
+    const cuts: ProposedCut[] = [
+      {
+        ...makeCut("FAT"),
+        passage: "It is important to note that we should proceed carefully.",
+        status: "pending",
+      },
+    ];
+
+    const result = applyCuts(document, cuts);
+    expect(result).toContain("It is important to note");
+  });
+
+  it("cleans up extra blank lines after removal", () => {
+    const doc = "Line one.\n\nRemove me.\n\nLine three.";
+    const cuts: ProposedCut[] = [
+      { ...makeCut("FAT"), passage: "Remove me.", status: "accepted" },
+    ];
+
+    const result = applyCuts(doc, cuts);
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+});
+
+describe("formatReport", () => {
+  it("produces a markdown report", () => {
+    const result: AdversarialEditResult = {
+      documentId: "doc-1",
+      cuts: parseAdversarialResponse(SAMPLE_RESPONSE),
+      distribution: computeDistribution(
+        parseAdversarialResponse(SAMPLE_RESPONSE),
+      ),
+      totalWordsProposed: 116,
+      model: "claude-sonnet-4-20250514",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+
+    const report = formatReport(result);
+    expect(report).toContain("# Adversarial Edit Report");
+    expect(report).toContain("6 passages identified");
+    expect(report).toContain("## Cut Type Distribution");
+    expect(report).toContain("## Proposed Cuts");
+    expect(report).toContain("OVER-EXPLAIN");
+  });
+
+  it("shows percentage distribution", () => {
+    const result: AdversarialEditResult = {
+      documentId: "doc-1",
+      cuts: [makeCut("OVER-EXPLAIN"), makeCut("OVER-EXPLAIN"), makeCut("FAT")],
+      distribution: computeDistribution([
+        makeCut("OVER-EXPLAIN"),
+        makeCut("OVER-EXPLAIN"),
+        makeCut("FAT"),
+      ]),
+      totalWordsProposed: 30,
+      model: "claude-sonnet-4-20250514",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+
+    const report = formatReport(result);
+    expect(report).toContain("OVER-EXPLAIN**: 2 (67%)");
+    expect(report).toContain("FAT**: 1 (33%)");
+  });
+});
+
+function makeCut(type: ProposedCut["type"]): ProposedCut {
+  return {
+    id: `test_${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    passage: "Test passage with some words in it.",
+    reason: "Test reason",
+    section: "Test Section",
+    wordCount: 7,
+    status: "pending",
+  };
+}

--- a/src/pipeline/adversarial-edit.ts
+++ b/src/pipeline/adversarial-edit.ts
@@ -1,0 +1,262 @@
+/**
+ * Adversarial editing pass for the Draftwell revision pipeline.
+ *
+ * Implements autonovel's technique: ask the LLM to identify what to *remove*
+ * from a document, classified by cut type. The cut list IS the revision plan.
+ *
+ * Key insight: Asking "cut N words" produces more actionable feedback than
+ * "improve this document." The cut classifications map directly to revision
+ * actions.
+ */
+
+import type {
+  AdversarialEditConfig,
+  AdversarialEditResult,
+  CutDistribution,
+  CutType,
+  ProposedCut,
+} from "./types";
+
+const CUT_TYPES: CutType[] = [
+  "OVER-EXPLAIN",
+  "REDUNDANT",
+  "FAT",
+  "TELL",
+  "STRUCTURAL",
+  "GENERIC",
+];
+
+const DEFAULT_CONFIG: Omit<AdversarialEditConfig, "apiKey"> = {
+  targetCuts: 15,
+  targetWordsCut: 500,
+  model: "claude-sonnet-4-20250514",
+  baseUrl: "https://api.anthropic.com",
+};
+
+function buildPrompt(document: string, config: AdversarialEditConfig): string {
+  return `You are a ruthless editor. Your job is to identify passages that should be CUT from this document. You are not rewriting — you are identifying what to remove.
+
+Propose exactly ${config.targetCuts} passages to cut, targeting approximately ${config.targetWordsCut} words total. For each cut, classify it as one of these types:
+
+- **OVER-EXPLAIN**: The passage explains something the reader already understands or restates what was just said in different words. (~32% of typical cuts)
+- **REDUNDANT**: The same idea appears elsewhere in the document. This passage adds nothing new. (~26% of typical cuts)
+- **FAT**: Unnecessary words, filler phrases, or verbose constructions that can be trimmed without losing meaning.
+- **TELL**: The passage tells the reader something instead of showing it. Assertions without evidence or illustration.
+- **STRUCTURAL**: Organizational problems — sections in the wrong order, unnecessary transitions, headers that don't earn their keep.
+- **GENERIC**: This passage could appear in any document on this topic. It contains no specific insight, data, or original thought.
+
+For each proposed cut, respond with this exact format:
+
+CUT <number>
+TYPE: <one of: OVER-EXPLAIN, REDUNDANT, FAT, TELL, STRUCTURAL, GENERIC>
+SECTION: <the heading or location where this passage appears>
+PASSAGE: """<exact quoted text to cut>"""
+REASON: <one sentence explaining why this should be cut>
+WORDS: <word count of the passage>
+
+---
+
+Here is the document to edit:
+
+${document}`;
+}
+
+function generateCutId(): string {
+  return `cut_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Parse the LLM response into structured ProposedCut objects. */
+export function parseAdversarialResponse(response: string): ProposedCut[] {
+  const cuts: ProposedCut[] = [];
+  const cutBlocks = response.split(/^CUT\s+\d+/m).filter((b) => b.trim());
+
+  for (const block of cutBlocks) {
+    const typeMatch = block.match(/^TYPE:\s*(.+)$/m);
+    const sectionMatch = block.match(/^SECTION:\s*(.+)$/m);
+    const passageMatch = block.match(/PASSAGE:\s*"""([\s\S]*?)"""/);
+    const reasonMatch = block.match(/^REASON:\s*(.+)$/m);
+    const wordsMatch = block.match(/^WORDS:\s*(\d+)/m);
+
+    if (!typeMatch || !passageMatch) continue;
+
+    const rawType = typeMatch[1].trim().toUpperCase() as CutType;
+    if (!CUT_TYPES.includes(rawType)) continue;
+
+    const passage = passageMatch[1].trim();
+
+    cuts.push({
+      id: generateCutId(),
+      type: rawType,
+      passage,
+      reason: reasonMatch?.[1]?.trim() ?? "",
+      section: sectionMatch?.[1]?.trim() ?? "",
+      wordCount: wordsMatch ? parseInt(wordsMatch[1], 10) : countWords(passage),
+      status: "pending",
+    });
+  }
+
+  return cuts;
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+/** Compute cut type distribution from a list of cuts. */
+export function computeDistribution(cuts: ProposedCut[]): CutDistribution {
+  const dist: CutDistribution = {
+    "OVER-EXPLAIN": 0,
+    REDUNDANT: 0,
+    FAT: 0,
+    TELL: 0,
+    STRUCTURAL: 0,
+    GENERIC: 0,
+  };
+
+  for (const cut of cuts) {
+    dist[cut.type]++;
+  }
+
+  return dist;
+}
+
+/** Call the Claude API to perform the adversarial edit pass. */
+async function callClaude(
+  prompt: string,
+  config: AdversarialEditConfig,
+): Promise<string> {
+  const baseUrl = config.baseUrl ?? DEFAULT_CONFIG.baseUrl;
+  const response = await fetch(`${baseUrl}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": config.apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: config.model,
+      max_tokens: 4096,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Claude API error (${response.status}): ${error}`);
+  }
+
+  const data = (await response.json()) as {
+    content: Array<{ type: string; text: string }>;
+  };
+
+  const textBlock = data.content.find((b) => b.type === "text");
+  if (!textBlock) {
+    throw new Error("No text content in Claude API response");
+  }
+
+  return textBlock.text;
+}
+
+/**
+ * Run the adversarial edit pass on a document.
+ *
+ * This is the main entry point. It sends the document to Claude with
+ * instructions to identify passages to cut, parses the response into
+ * structured cuts, and computes the quality distribution.
+ */
+export async function adversarialEdit(
+  document: string,
+  documentId: string,
+  config: Partial<AdversarialEditConfig> & { apiKey: string },
+): Promise<AdversarialEditResult> {
+  const fullConfig: AdversarialEditConfig = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  };
+
+  const prompt = buildPrompt(document, fullConfig);
+  const response = await callClaude(prompt, fullConfig);
+  const cuts = parseAdversarialResponse(response);
+  const distribution = computeDistribution(cuts);
+  const totalWordsProposed = cuts.reduce((sum, c) => sum + c.wordCount, 0);
+
+  return {
+    documentId,
+    cuts,
+    distribution,
+    totalWordsProposed,
+    model: fullConfig.model,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Apply accepted cuts to a document by removing the accepted passages.
+ * Returns the modified document text.
+ */
+export function applyCuts(
+  document: string,
+  cuts: ProposedCut[],
+): string {
+  const accepted = cuts.filter((c) => c.status === "accepted");
+
+  // Sort by passage length descending to avoid offset issues
+  // when removing longer passages that might contain shorter ones
+  const sorted = [...accepted].sort(
+    (a, b) => b.passage.length - a.passage.length,
+  );
+
+  let result = document;
+  for (const cut of sorted) {
+    result = result.replace(cut.passage, "");
+  }
+
+  // Clean up double blank lines left by removals
+  result = result.replace(/\n{3,}/g, "\n\n");
+
+  return result;
+}
+
+/**
+ * Format the adversarial edit result as a human-readable report.
+ */
+export function formatReport(result: AdversarialEditResult): string {
+  const lines: string[] = [];
+
+  lines.push("# Adversarial Edit Report");
+  lines.push("");
+  lines.push(
+    `**${result.cuts.length} passages identified** | ~${result.totalWordsProposed} words proposed for cutting`,
+  );
+  lines.push("");
+
+  // Distribution summary
+  lines.push("## Cut Type Distribution");
+  lines.push("");
+  const total = result.cuts.length || 1;
+  for (const type of CUT_TYPES) {
+    const count = result.distribution[type];
+    const pct = Math.round((count / total) * 100);
+    lines.push(`- **${type}**: ${count} (${pct}%)`);
+  }
+  lines.push("");
+
+  // Individual cuts
+  lines.push("## Proposed Cuts");
+  lines.push("");
+  for (let i = 0; i < result.cuts.length; i++) {
+    const cut = result.cuts[i];
+    lines.push(`### Cut ${i + 1}: ${cut.type}`);
+    lines.push("");
+    lines.push(`**Section**: ${cut.section}`);
+    lines.push(`**Words**: ${cut.wordCount}`);
+    lines.push(`**Status**: ${cut.status}`);
+    lines.push("");
+    lines.push(`> ${cut.passage.replace(/\n/g, "\n> ")}`);
+    lines.push("");
+    lines.push(`*${cut.reason}*`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Draftwell revision pipeline.
+ *
+ * Pipeline stages:
+ *   Draft -> Critical Review -> [Adversarial Edit] -> Revision -> Refinement
+ *
+ * The adversarial edit pass is optional, inserted between review and revision.
+ * It identifies passages to cut rather than improve, producing a concrete
+ * revision plan based on what should be removed.
+ */
+
+export {
+  adversarialEdit,
+  applyCuts,
+  computeDistribution,
+  formatReport,
+  parseAdversarialResponse,
+} from "./adversarial-edit";
+
+export type {
+  AdversarialEditConfig,
+  AdversarialEditResult,
+  CutDistribution,
+  CutType,
+  PipelineStage,
+  ProposedCut,
+  Section,
+} from "./types";

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Core types for the Draftwell revision pipeline.
+ */
+
+/** Document section parsed from markdown. */
+export interface Section {
+  heading: string;
+  level: number;
+  content: string;
+  startLine: number;
+  tokens: number;
+}
+
+/** Cut classification types from the adversarial editing technique. */
+export type CutType =
+  | "OVER-EXPLAIN"
+  | "REDUNDANT"
+  | "FAT"
+  | "TELL"
+  | "STRUCTURAL"
+  | "GENERIC";
+
+/** A single proposed cut from the adversarial edit pass. */
+export interface ProposedCut {
+  id: string;
+  type: CutType;
+  passage: string;
+  reason: string;
+  section: string;
+  wordCount: number;
+  status: "pending" | "accepted" | "rejected";
+}
+
+/** Distribution of cut types as a document quality signal. */
+export type CutDistribution = Record<CutType, number>;
+
+/** Result of an adversarial edit pass on a document. */
+export interface AdversarialEditResult {
+  documentId: string;
+  cuts: ProposedCut[];
+  distribution: CutDistribution;
+  totalWordsProposed: number;
+  model: string;
+  createdAt: string;
+}
+
+/** Configuration for the adversarial edit pass. */
+export interface AdversarialEditConfig {
+  /** Target number of cuts to identify (default: 15). */
+  targetCuts: number;
+  /** Approximate word count to propose cutting (guides the LLM). */
+  targetWordsCut: number;
+  /** Claude model to use. */
+  model: string;
+  /** API key for Claude. */
+  apiKey: string;
+  /** Optional base URL for the API. */
+  baseUrl?: string;
+}
+
+/** Stage in the revision pipeline where adversarial edit fits. */
+export type PipelineStage =
+  | "review"
+  | "adversarial-edit"
+  | "revision"
+  | "refinement";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
   },
-  "include": ["src", "workers"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,25 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "include": ["src", "workers"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Closes #5

> **Note:** Builder completed changes but exited before creating a PR. PR created via direct completion.

## Changes

```
package.json                                    |  57 +----
 src/pipeline/__tests__/adversarial-edit.test.ts | 298 ++++++++++++++++++++++++
 src/pipeline/adversarial-edit.ts                | 262 +++++++++++++++++++++
 src/pipeline/index.ts                           |  28 +++
 src/pipeline/types.ts                           |  66 ++++++
 tsconfig.json                                   |  24 +-
 6 files changed, 670 insertions(+), 65 deletions(-)
```

## Commits

- `40606b7 feat: add adversarial editing pass with typed cut classifications`

## Test plan

- [ ] Verify changes match issue requirements
- [ ] Confirm tests pass