### PR TITLE
feat: add document CRUD API and document list UI

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -25,6 +25,16 @@ interface Project {
   updated_at: string;
 }
 
+interface Document {
+  id: string;
+  project_id: string;
+  title: string;
+  current_revision: number;
+  r2_key: string;
+  created_at: string;
+  updated_at: string;
+}
+
 // Session configuration
 const SESSION_COOKIE_NAME = "draftwell-session";
 const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -461,6 +471,234 @@ async function handleDeleteProject(env: Env, id: string, userId: string): Promis
   return json({ success: true });
 }
 
+// Helper to verify project belongs to user
+async function verifyProjectOwnership(
+  env: Env,
+  projectId: string,
+  userId: string,
+): Promise<boolean> {
+  const project = await env.DB.prepare("SELECT id FROM projects WHERE id = ? AND user_id = ?")
+    .bind(projectId, userId)
+    .first();
+  return !!project;
+}
+
+// Document handlers
+async function handleGetDocuments(
+  env: Env,
+  projectId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const { results } = await env.DB.prepare(
+    "SELECT id, project_id, title, current_revision, r2_key, created_at, updated_at FROM documents WHERE project_id = ? ORDER BY created_at DESC",
+  )
+    .bind(projectId)
+    .all<Document>();
+  return json({ documents: results });
+}
+
+async function handleGetDocument(
+  env: Env,
+  projectId: string,
+  docId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const doc = await env.DB.prepare(
+    "SELECT id, project_id, title, current_revision, r2_key, created_at, updated_at FROM documents WHERE id = ? AND project_id = ?",
+  )
+    .bind(docId, projectId)
+    .first<Document>();
+
+  if (!doc) {
+    return error("Document not found", 404);
+  }
+
+  // Fetch content from R2
+  const object = await env.CONTENT_BUCKET.get(doc.r2_key);
+  const content = object ? await object.text() : "";
+
+  return json({ document: doc, content });
+}
+
+async function handleCreateDocument(
+  env: Env,
+  request: Request,
+  projectId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const body = (await request.json()) as { title?: string; content?: string };
+  const { title, content } = body;
+
+  if (!title) {
+    return error("Title is required");
+  }
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const r2Key = `users/${userId}/projects/${projectId}/documents/${id}/rev_0.md`;
+
+  // Store content in R2
+  await env.CONTENT_BUCKET.put(r2Key, content || "");
+
+  // Create document record in D1
+  await env.DB.prepare(
+    "INSERT INTO documents (id, project_id, title, current_revision, r2_key, created_at, updated_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+  )
+    .bind(id, projectId, title, r2Key, now, now)
+    .run();
+
+  // Create initial revision record
+  const revisionId = crypto.randomUUID();
+  await env.DB.prepare(
+    "INSERT INTO revisions (id, document_id, revision_number, r2_key, created_at) VALUES (?, ?, 0, ?, ?)",
+  )
+    .bind(revisionId, id, r2Key, now)
+    .run();
+
+  return json(
+    {
+      document: {
+        id,
+        project_id: projectId,
+        title,
+        current_revision: 0,
+        r2_key: r2Key,
+        created_at: now,
+        updated_at: now,
+      },
+    },
+    201,
+  );
+}
+
+async function handleUpdateDocument(
+  env: Env,
+  request: Request,
+  projectId: string,
+  docId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const existing = await env.DB.prepare(
+    "SELECT id, current_revision FROM documents WHERE id = ? AND project_id = ?",
+  )
+    .bind(docId, projectId)
+    .first<{ id: string; current_revision: number }>();
+
+  if (!existing) {
+    return error("Document not found", 404);
+  }
+
+  const body = (await request.json()) as { content?: string; title?: string };
+
+  if (body.content === undefined && body.title === undefined) {
+    return error("No fields to update");
+  }
+
+  const now = new Date().toISOString();
+  const updates: string[] = [];
+  const values: (string | number | null)[] = [];
+
+  if (body.content !== undefined) {
+    const newRevision = existing.current_revision + 1;
+    const newR2Key = `users/${userId}/projects/${projectId}/documents/${docId}/rev_${newRevision}.md`;
+
+    // Store new content in R2
+    await env.CONTENT_BUCKET.put(newR2Key, body.content);
+
+    // Create new revision record
+    const revisionId = crypto.randomUUID();
+    await env.DB.prepare(
+      "INSERT INTO revisions (id, document_id, revision_number, r2_key, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(revisionId, docId, newRevision, newR2Key, now)
+      .run();
+
+    updates.push("current_revision = ?");
+    values.push(newRevision);
+    updates.push("r2_key = ?");
+    values.push(newR2Key);
+  }
+
+  if (body.title !== undefined) {
+    updates.push("title = ?");
+    values.push(body.title);
+  }
+
+  updates.push("updated_at = ?");
+  values.push(now);
+  values.push(docId);
+  values.push(projectId);
+
+  await env.DB.prepare(
+    `UPDATE documents SET ${updates.join(", ")} WHERE id = ? AND project_id = ?`,
+  )
+    .bind(...values)
+    .run();
+
+  const doc = await env.DB.prepare(
+    "SELECT id, project_id, title, current_revision, r2_key, created_at, updated_at FROM documents WHERE id = ?",
+  )
+    .bind(docId)
+    .first<Document>();
+
+  return json({ document: doc });
+}
+
+async function handleDeleteDocument(
+  env: Env,
+  projectId: string,
+  docId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const existing = await env.DB.prepare(
+    "SELECT id, r2_key, current_revision FROM documents WHERE id = ? AND project_id = ?",
+  )
+    .bind(docId, projectId)
+    .first<{ id: string; r2_key: string; current_revision: number }>();
+
+  if (!existing) {
+    return error("Document not found", 404);
+  }
+
+  // Clean up R2 objects for all revisions
+  const { results: revisions } = await env.DB.prepare(
+    "SELECT r2_key FROM revisions WHERE document_id = ?",
+  )
+    .bind(docId)
+    .all<{ r2_key: string }>();
+
+  for (const rev of revisions) {
+    await env.CONTENT_BUCKET.delete(rev.r2_key);
+  }
+
+  // Delete from D1 (cascade will handle revisions table)
+  await env.DB.prepare("DELETE FROM documents WHERE id = ? AND project_id = ?")
+    .bind(docId, projectId)
+    .run();
+
+  return json({ success: true });
+}
+
 // Main request handler
 export const onRequest: PagesFunction<Env> = async (context) => {
   const { request, env, params } = context;
@@ -538,6 +776,39 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       }
       if (method === "DELETE") {
         return handleDeleteProject(env, projectId, user.id);
+      }
+    }
+
+    // Document endpoints (require authentication)
+    const docsMatch = path.match(/^\/api\/projects\/([^/]+)\/documents$/);
+    if (docsMatch) {
+      const user = await getAuthenticatedUser(env, request);
+      if (!user) return error("Unauthorized", 401);
+      const projectId = docsMatch[1];
+
+      if (method === "GET") {
+        return handleGetDocuments(env, projectId, user.id);
+      }
+      if (method === "POST") {
+        return handleCreateDocument(env, request, projectId, user.id);
+      }
+    }
+
+    const docMatch = path.match(/^\/api\/projects\/([^/]+)\/documents\/([^/]+)$/);
+    if (docMatch) {
+      const user = await getAuthenticatedUser(env, request);
+      if (!user) return error("Unauthorized", 401);
+      const projectId = docMatch[1];
+      const docId = docMatch[2];
+
+      if (method === "GET") {
+        return handleGetDocument(env, projectId, docId, user.id);
+      }
+      if (method === "PUT") {
+        return handleUpdateDocument(env, request, projectId, docId, user.id);
+      }
+      if (method === "DELETE") {
+        return handleDeleteDocument(env, projectId, docId, user.id);
       }
     }
 

--- a/functions/api/__tests__/documents.test.ts
+++ b/functions/api/__tests__/documents.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onRequest } from "../[[route]]";
+
+// Mock D1 database
+function createMockDb() {
+  const mockStatement = {
+    bind: vi.fn().mockReturnThis(),
+    all: vi.fn(),
+    first: vi.fn(),
+    run: vi.fn(),
+  };
+
+  return {
+    prepare: vi.fn().mockReturnValue(mockStatement),
+    _statement: mockStatement,
+  };
+}
+
+// Mock R2 bucket
+function createMockBucket() {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function createContext(
+  method: string,
+  path: string,
+  options: {
+    body?: unknown;
+    db?: ReturnType<typeof createMockDb>;
+    bucket?: ReturnType<typeof createMockBucket>;
+    cookie?: string;
+    appName?: string;
+  } = {},
+) {
+  const url = new URL(path, "http://localhost");
+  const route = path.replace("/api/", "").split("/").filter(Boolean);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options.cookie) {
+    headers.Cookie = options.cookie;
+  }
+
+  const request = new Request(url.toString(), {
+    method,
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  return {
+    request,
+    env: {
+      DB: options.db ?? createMockDb(),
+      CONTENT_BUCKET: options.bucket ?? createMockBucket(),
+      APP_NAME: options.appName ?? "test-app",
+    },
+    params: { route: route.length ? route : undefined },
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+    next: vi.fn(),
+    data: {},
+  } as unknown as Parameters<typeof onRequest>[0];
+}
+
+// Helper to set up an authenticated user context
+function setupAuthenticatedDb(mockDb: ReturnType<typeof createMockDb>) {
+  // The first call to getSessionUser queries sessions+users join
+  // We need to handle .first() calls properly
+  const mockUser = {
+    id: "user-1",
+    email: "test@example.com",
+    name: "Test User",
+    created_at: "2024-01-01",
+  };
+
+  // When getAuthenticatedUser is called, it does:
+  // 1. getSessionIdFromCookie (no DB)
+  // 2. getSessionUser: DB.prepare(SELECT u.* FROM sessions s JOIN users u...).bind(sessionId).first()
+  // The mock will return mockUser on the first .first() call
+  mockDb._statement.first.mockResolvedValueOnce(mockUser);
+
+  return mockUser;
+}
+
+describe("Document API Routes", () => {
+  const sessionCookie = "draftwell-session=test-session-id";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/projects/:projectId/documents", () => {
+    it("returns 401 when not authenticated", async () => {
+      const context = createContext("GET", "/api/projects/proj-1/documents");
+      const response = await onRequest(context);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 404 when project not found", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership returns null
+      mockDb._statement.first.mockResolvedValueOnce(null);
+
+      const context = createContext("GET", "/api/projects/proj-1/documents", {
+        db: mockDb,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(404);
+    });
+
+    it("returns documents list", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // documents query
+      const mockDocs = [
+        {
+          id: "doc-1",
+          project_id: "proj-1",
+          title: "My Document",
+          current_revision: 0,
+          r2_key: "users/user-1/projects/proj-1/documents/doc-1/rev_0.md",
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+        },
+      ];
+      mockDb._statement.all.mockResolvedValueOnce({ results: mockDocs });
+
+      const context = createContext("GET", "/api/projects/proj-1/documents", {
+        db: mockDb,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.documents).toEqual(mockDocs);
+    });
+  });
+
+  describe("POST /api/projects/:projectId/documents", () => {
+    it("returns 401 when not authenticated", async () => {
+      const context = createContext("POST", "/api/projects/proj-1/documents", {
+        body: { title: "New Doc" },
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 400 when title is missing", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+
+      const context = createContext("POST", "/api/projects/proj-1/documents", {
+        db: mockDb,
+        cookie: sessionCookie,
+        body: {},
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe("Title is required");
+    });
+
+    it("creates a document successfully", async () => {
+      const mockDb = createMockDb();
+      const mockBucket = createMockBucket();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // insert document
+      mockDb._statement.run.mockResolvedValueOnce({ success: true });
+      // insert revision
+      mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+      const context = createContext("POST", "/api/projects/proj-1/documents", {
+        db: mockDb,
+        bucket: mockBucket,
+        cookie: sessionCookie,
+        body: { title: "My New Doc", content: "Hello world" },
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.document.title).toBe("My New Doc");
+      expect(data.document.current_revision).toBe(0);
+      expect(data.document.project_id).toBe("proj-1");
+      expect(mockBucket.put).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("GET /api/projects/:projectId/documents/:docId", () => {
+    it("returns document with content", async () => {
+      const mockDb = createMockDb();
+      const mockBucket = createMockBucket();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // get document
+      const mockDoc = {
+        id: "doc-1",
+        project_id: "proj-1",
+        title: "My Doc",
+        current_revision: 0,
+        r2_key: "users/user-1/projects/proj-1/documents/doc-1/rev_0.md",
+        created_at: "2024-01-01",
+        updated_at: "2024-01-01",
+      };
+      mockDb._statement.first.mockResolvedValueOnce(mockDoc);
+      // R2 get
+      mockBucket.get.mockResolvedValueOnce({ text: () => Promise.resolve("# Hello") });
+
+      const context = createContext("GET", "/api/projects/proj-1/documents/doc-1", {
+        db: mockDb,
+        bucket: mockBucket,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.document).toEqual(mockDoc);
+      expect(data.content).toBe("# Hello");
+    });
+
+    it("returns 404 when document not found", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // document not found
+      mockDb._statement.first.mockResolvedValueOnce(null);
+
+      const context = createContext("GET", "/api/projects/proj-1/documents/nonexistent", {
+        db: mockDb,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("PUT /api/projects/:projectId/documents/:docId", () => {
+    it("updates document content with new revision", async () => {
+      const mockDb = createMockDb();
+      const mockBucket = createMockBucket();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // get existing doc
+      mockDb._statement.first.mockResolvedValueOnce({ id: "doc-1", current_revision: 2 });
+      // insert revision
+      mockDb._statement.run.mockResolvedValueOnce({ success: true });
+      // update document
+      mockDb._statement.run.mockResolvedValueOnce({ success: true });
+      // fetch updated doc
+      const updatedDoc = {
+        id: "doc-1",
+        project_id: "proj-1",
+        title: "My Doc",
+        current_revision: 3,
+        r2_key: "users/user-1/projects/proj-1/documents/doc-1/rev_3.md",
+        created_at: "2024-01-01",
+        updated_at: "2024-01-02",
+      };
+      mockDb._statement.first.mockResolvedValueOnce(updatedDoc);
+
+      const context = createContext("PUT", "/api/projects/proj-1/documents/doc-1", {
+        db: mockDb,
+        bucket: mockBucket,
+        cookie: sessionCookie,
+        body: { content: "Updated content" },
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.document.current_revision).toBe(3);
+      expect(mockBucket.put).toHaveBeenCalledOnce();
+    });
+
+    it("returns 404 when document not found", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // document not found
+      mockDb._statement.first.mockResolvedValueOnce(null);
+
+      const context = createContext("PUT", "/api/projects/proj-1/documents/nonexistent", {
+        db: mockDb,
+        cookie: sessionCookie,
+        body: { content: "new content" },
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/projects/:projectId/documents/:docId", () => {
+    it("deletes document and cleans up R2", async () => {
+      const mockDb = createMockDb();
+      const mockBucket = createMockBucket();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // existing doc
+      mockDb._statement.first.mockResolvedValueOnce({
+        id: "doc-1",
+        r2_key: "key",
+        current_revision: 1,
+      });
+      // revisions list
+      mockDb._statement.all.mockResolvedValueOnce({
+        results: [{ r2_key: "rev_0.md" }, { r2_key: "rev_1.md" }],
+      });
+      // delete
+      mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+      const context = createContext("DELETE", "/api/projects/proj-1/documents/doc-1", {
+        db: mockDb,
+        bucket: mockBucket,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(mockBucket.delete).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns 404 when document not found", async () => {
+      const mockDb = createMockDb();
+      setupAuthenticatedDb(mockDb);
+      // verifyProjectOwnership
+      mockDb._statement.first.mockResolvedValueOnce({ id: "proj-1" });
+      // doc not found
+      mockDb._statement.first.mockResolvedValueOnce(null);
+
+      const context = createContext("DELETE", "/api/projects/proj-1/documents/nonexistent", {
+        db: mockDb,
+        cookie: sessionCookie,
+      });
+      const response = await onRequest(context);
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,19 +1,33 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { EmptyState } from "@/components/EmptyState";
 import type { Project } from "@/components/ProjectCard";
 import { ProjectForm } from "@/components/ProjectForm";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/use-auth";
 
+interface Document {
+  id: string;
+  project_id: string;
+  title: string;
+  current_revision: number;
+  r2_key: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { user } = useAuth();
   const [project, setProject] = useState<Project | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingDocs, setIsLoadingDocs] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
+  const [isCreatingDoc, setIsCreatingDoc] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchProject = useCallback(async () => {
@@ -37,9 +51,27 @@ export function ProjectDetailPage() {
     }
   }, [id, user]);
 
+  const fetchDocuments = useCallback(async () => {
+    if (!id || !user) return;
+
+    try {
+      const response = await fetch(`/api/projects/${id}/documents`, {
+        credentials: "include",
+      });
+      if (!response.ok) throw new Error("Failed to fetch documents");
+      const data = await response.json();
+      setDocuments(data.documents);
+    } catch {
+      // Document loading failure is non-fatal
+    } finally {
+      setIsLoadingDocs(false);
+    }
+  }, [id, user]);
+
   useEffect(() => {
     fetchProject();
-  }, [fetchProject]);
+    fetchDocuments();
+  }, [fetchProject, fetchDocuments]);
 
   const handleUpdate = async (data: { name: string; description: string }) => {
     if (!id || !user) return;
@@ -70,6 +102,38 @@ export function ProjectDetailPage() {
     });
     if (!response.ok) throw new Error("Failed to delete project");
     navigate("/projects");
+  };
+
+  const handleCreateDocument = async () => {
+    if (!id || !user) return;
+
+    setIsCreatingDoc(true);
+    try {
+      const response = await fetch(`/api/projects/${id}/documents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ title: "Untitled Document" }),
+      });
+      if (!response.ok) throw new Error("Failed to create document");
+      const data = await response.json();
+      navigate(`/projects/${id}/documents/${data.document.id}/edit`);
+    } catch {
+      // Creation failure handled by the UI remaining on current page
+    } finally {
+      setIsCreatingDoc(false);
+    }
+  };
+
+  const handleDeleteDocument = async (docId: string) => {
+    if (!id || !user) return;
+
+    const response = await fetch(`/api/projects/${id}/documents/${docId}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!response.ok) throw new Error("Failed to delete document");
+    setDocuments((prev) => prev.filter((d) => d.id !== docId));
   };
 
   if (isLoading) {
@@ -179,6 +243,72 @@ export function ProjectDetailPage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Documents Section */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Documents</CardTitle>
+            <Button size="sm" onClick={handleCreateDocument} disabled={isCreatingDoc}>
+              {isCreatingDoc ? "Creating..." : "New Document"}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isLoadingDocs ? (
+            <div className="space-y-3">
+              <div className="h-12 animate-pulse rounded bg-muted" />
+              <div className="h-12 animate-pulse rounded bg-muted" />
+            </div>
+          ) : documents.length === 0 ? (
+            <EmptyState
+              title="No documents yet"
+              description="Create your first document to start writing."
+              action={{
+                label: "New Document",
+                onClick: handleCreateDocument,
+              }}
+            />
+          ) : (
+            <div className="space-y-2">
+              {documents.map((doc) => (
+                <div
+                  key={doc.id}
+                  className="flex items-center justify-between rounded-lg border p-3"
+                >
+                  <Link
+                    to={`/projects/${id}/documents/${doc.id}/edit`}
+                    className="flex-1 hover:underline"
+                  >
+                    <div className="font-medium">{doc.title}</div>
+                    <div className="text-xs text-muted-foreground">
+                      Created {new Date(doc.created_at).toLocaleDateString()}
+                      {doc.updated_at !== doc.created_at && (
+                        <> • Updated {new Date(doc.updated_at).toLocaleDateString()}</>
+                      )}
+                      {doc.current_revision > 0 && (
+                        <> • Rev {doc.current_revision}</>
+                      )}
+                    </div>
+                  </Link>
+                  <ConfirmDialog
+                    trigger={
+                      <Button variant="ghost" size="sm" className="text-destructive">
+                        Delete
+                      </Button>
+                    }
+                    title="Delete Document"
+                    description={`Are you sure you want to delete "${doc.title}"? This action cannot be undone.`}
+                    confirmLabel="Delete"
+                    variant="destructive"
+                    onConfirm={() => handleDeleteDocument(doc.id)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Implement document management backend API endpoints and integrate document listing into the ProjectDetailPage UI, enabling users to create, read, update, and delete documents within projects.

## Changes
- Add Document interface and 5 CRUD handler functions in `functions/api/[[route]].ts`: list, get, create, update (with revision tracking), and delete (with R2 cleanup)
- Add route matching for `/api/projects/:projectId/documents` and `/api/projects/:projectId/documents/:docId`
- Add `verifyProjectOwnership` helper to authorize document operations
- Update `src/pages/ProjectDetailPage.tsx` with a Documents section showing document list, "New Document" button, delete per document, and links to the edit page
- Add `functions/api/__tests__/documents.test.ts` with 10 tests covering all document endpoints (auth, validation, CRUD, R2 interactions)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| GET /api/projects/:projectId/documents lists documents | Done | Implemented and tested |
| POST /api/projects/:projectId/documents creates document + R2 + revision | Done | Implemented and tested |
| GET /api/projects/:projectId/documents/:docId returns metadata + R2 content | Done | Implemented and tested |
| PUT /api/projects/:projectId/documents/:docId creates new revision in R2 | Done | Implemented and tested |
| DELETE /api/projects/:projectId/documents/:docId removes D1 + R2 | Done | Implemented and tested |
| All endpoints verify project ownership | Done | verifyProjectOwnership called in every handler |
| ProjectDetailPage shows document list | Done | Documents section with EmptyState fallback |
| New Document button creates and navigates to edit | Done | POST then navigate |
| Delete button per document | Done | With ConfirmDialog |
| Tests for document endpoints | Done | 10 tests in documents.test.ts |

## Test Plan
- `pnpm run build` passes (tsc + vite)
- `pnpm run lint:fix` passes (biome)
- `pnpm run test` -- all 85 tests pass; 3 pre-existing empty suite failures in packages/ are unrelated

Closes #13