### PR TITLE
feat: add Orwell/Zinsser/Ogilvy language discipline rules

### DIFF
--- a/packages/styleguide/package-lock.json
+++ b/packages/styleguide/package-lock.json
@@ -9,8 +9,803 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^25.6.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^2.0.0"
       }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
@@ -20,6 +815,491 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -42,6 +1322,172 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@draftwell/styleguide",
   "version": "0.1.0",
-  "description": "Tiered anti-slop styleguide with mechanical detection",
+  "description": "Anti-slop styleguide and language discipline rules for draftwell's review pipeline",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "node --test dist/**/*.test.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "check": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/styleguide/src/__tests__/checker.test.ts
+++ b/packages/styleguide/src/__tests__/checker.test.ts
@@ -1,14 +1,13 @@
-import { describe, it } from "node:test";
-import * as assert from "node:assert/strict";
-import { check } from "./checker.js";
-import { defaultStyleguide } from "./rules/index.js";
+import { describe, expect, it } from "vitest";
+import { check } from "../checker.js";
+import { defaultStyleguide } from "../rules/index.js";
 
 describe("check", () => {
   it("returns clean report for non-AI text", () => {
     const doc = "The cat sat on the mat. It was a cold Tuesday morning.";
     const report = check(doc, defaultStyleguide);
-    assert.equal(report.counts.error, 0);
-    assert.ok(report.score < 1, `Score ${report.score} should be < 1`);
+    expect(report.counts.error).toBe(0);
+    expect(report.score).toBeLessThan(1);
   });
 
   it("detects kill-on-sight words", () => {
@@ -17,9 +16,9 @@ describe("check", () => {
     const errorIds = report.results
       .filter((r) => r.severity === "error")
       .map((r) => r.ruleId);
-    assert.ok(errorIds.includes("word-delve"), "Should detect 'delve'");
-    assert.ok(errorIds.includes("word-tapestry"), "Should detect 'tapestry'");
-    assert.ok(errorIds.includes("word-multifaceted"), "Should detect 'multifaceted'");
+    expect(errorIds).toContain("word-delve");
+    expect(errorIds).toContain("word-tapestry");
+    expect(errorIds).toContain("word-multifaceted");
   });
 
   it("detects banned phrases", () => {
@@ -29,18 +28,9 @@ describe("check", () => {
     const errorIds = report.results
       .filter((r) => r.severity === "error")
       .map((r) => r.ruleId);
-    assert.ok(
-      errorIds.includes("phrase-important-to-note"),
-      "Should detect 'it's important to note'",
-    );
-    assert.ok(
-      errorIds.includes("phrase-cannot-be-overstated"),
-      "Should detect 'cannot be overstated'",
-    );
-    assert.ok(
-      errorIds.includes("phrase-dive-into"),
-      "Should detect 'let's dive into'",
-    );
+    expect(errorIds).toContain("phrase-important-to-note");
+    expect(errorIds).toContain("phrase-cannot-be-overstated");
+    expect(errorIds).toContain("phrase-dive-into");
   });
 
   it("detects chatbot artifacts", () => {
@@ -50,42 +40,27 @@ describe("check", () => {
     const errorIds = report.results
       .filter((r) => r.severity === "error")
       .map((r) => r.ruleId);
-    assert.ok(errorIds.includes("phrase-as-an-ai"), "Should detect 'as an AI'");
-    assert.ok(
-      errorIds.includes("phrase-happy-to-help"),
-      "Should detect 'happy to help'",
-    );
-    assert.ok(
-      errorIds.includes("phrase-hope-this-helps"),
-      "Should detect 'hope this helps'",
-    );
-    assert.ok(
-      errorIds.includes("phrase-feel-free-to"),
-      "Should detect 'feel free to'",
-    );
-    assert.ok(
-      errorIds.includes("phrase-great-question"),
-      "Should detect 'great question'",
-    );
+    expect(errorIds).toContain("phrase-as-an-ai");
+    expect(errorIds).toContain("phrase-happy-to-help");
+    expect(errorIds).toContain("phrase-hope-this-helps");
+    expect(errorIds).toContain("phrase-feel-free-to");
+    expect(errorIds).toContain("phrase-great-question");
   });
 
   it("returns correct location info", () => {
     const doc = "First line is fine.\nSecond line has delve in it.\nThird line.";
     const report = check(doc, defaultStyleguide);
     const delveResult = report.results.find((r) => r.ruleId === "word-delve");
-    assert.ok(delveResult, "Should find delve");
-    assert.equal(delveResult!.line, 2, "Should be on line 2");
-    assert.equal(delveResult!.match, "delve");
+    expect(delveResult).toBeDefined();
+    expect(delveResult!.line).toBe(2);
+    expect(delveResult!.match).toBe("delve");
   });
 
   it("includes suggestions", () => {
     const doc = "We need to leverage this robust framework to streamline operations.";
     const report = check(doc, defaultStyleguide);
     for (const result of report.results) {
-      assert.ok(
-        result.suggestion,
-        `Result for ${result.ruleId} should have a suggestion`,
-      );
+      expect(result.suggestion).toBeTruthy();
     }
   });
 
@@ -102,25 +77,21 @@ describe("check", () => {
     const cleanReport = check(cleanDoc, defaultStyleguide);
     const slopReport = check(slopDoc, defaultStyleguide);
 
-    assert.ok(cleanReport.score >= 0, "Clean score >= 0");
-    assert.ok(cleanReport.score <= 10, "Clean score <= 10");
-    assert.ok(slopReport.score >= 0, "Slop score >= 0");
-    assert.ok(slopReport.score <= 10, "Slop score <= 10");
-    assert.ok(
-      slopReport.score > cleanReport.score,
-      `Slop score (${slopReport.score}) should exceed clean score (${cleanReport.score})`,
-    );
+    expect(cleanReport.score).toBeGreaterThanOrEqual(0);
+    expect(cleanReport.score).toBeLessThanOrEqual(10);
+    expect(slopReport.score).toBeGreaterThanOrEqual(0);
+    expect(slopReport.score).toBeLessThanOrEqual(10);
+    expect(slopReport.score).toBeGreaterThan(cleanReport.score);
   });
 
   it("separates counts by severity", () => {
     const doc =
       "We must delve into how to leverage this. Furthermore, it's important to note the nuanced approach.";
     const report = check(doc, defaultStyleguide);
-    assert.ok(report.counts.error > 0, "Should have errors");
-    assert.ok(report.counts.warning > 0, "Should have warnings");
-    assert.ok(
-      report.totalIssues === report.counts.error + report.counts.warning + report.counts.info,
-      "Total should equal sum of counts",
+    expect(report.counts.error).toBeGreaterThan(0);
+    expect(report.counts.warning).toBeGreaterThan(0);
+    expect(report.totalIssues).toBe(
+      report.counts.error + report.counts.warning + report.counts.info + report.counts.suggestion,
     );
   });
 });
@@ -135,8 +106,8 @@ describe("structural checks", () => {
     const emDashResult = report.structuralResults.find(
       (r) => r.ruleId === "structural-em-dash-density",
     );
-    assert.ok(emDashResult, "Should detect excessive em-dash density");
-    assert.ok(emDashResult!.value > 5, `Density ${emDashResult!.value} should exceed threshold`);
+    expect(emDashResult).toBeDefined();
+    expect(emDashResult!.value).toBeGreaterThan(5);
   });
 
   it("does not flag normal em-dash usage", () => {
@@ -150,7 +121,7 @@ describe("structural checks", () => {
     const emDashResult = report.structuralResults.find(
       (r) => r.ruleId === "structural-em-dash-density",
     );
-    assert.equal(emDashResult, undefined, "Should not flag normal em-dash usage");
+    expect(emDashResult).toBeUndefined();
   });
 
   it("detects sentence length uniformity", () => {
@@ -172,6 +143,6 @@ describe("structural checks", () => {
     const uniformResult = report.structuralResults.find(
       (r) => r.ruleId === "structural-sentence-uniformity",
     );
-    assert.ok(uniformResult, "Should detect sentence uniformity");
+    expect(uniformResult).toBeDefined();
   });
 });

--- a/packages/styleguide/src/__tests__/discipline.test.ts
+++ b/packages/styleguide/src/__tests__/discipline.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { checkDiscipline, checkPass, checkAllPasses, allRules } from "../discipline.js";
+import { zinsserPasses } from "../rules/zinsser.js";
+
+describe("checkDiscipline", () => {
+  it("returns findings from all frameworks", () => {
+    const result = checkDiscipline(
+      "We need to leverage synergy to think outside the box. " +
+      "Each and every team member should make contact with the client. " +
+      "Perhaps you could utilize the aforementioned methodology.",
+    );
+    const frameworks = new Set(result.findings.map((f) => f.framework));
+    expect(frameworks.has("orwell")).toBe(true);
+    expect(frameworks.has("zinsser")).toBe(true);
+    expect(frameworks.has("ogilvy")).toBe(true);
+  });
+
+  it("includes word count", () => {
+    const result = checkDiscipline("One two three four five.");
+    expect(result.wordCount).toBe(5);
+  });
+
+  it("always includes the escape clause", () => {
+    const result = checkDiscipline("Clean text.");
+    expect(result.escapeClause).toContain("Break any of these rules");
+    expect(result.escapeClause).toContain("barbarous");
+  });
+
+  it("sorts findings by offset", () => {
+    const result = checkDiscipline(
+      "We need to leverage this. We should utilize that. We must facilitate it.",
+    );
+    for (let i = 1; i < result.findings.length; i++) {
+      expect(result.findings[i].offset).toBeGreaterThanOrEqual(
+        result.findings[i - 1].offset,
+      );
+    }
+  });
+
+  it("returns empty findings for clean text", () => {
+    const result = checkDiscipline("The cat sat on the mat.");
+    expect(result.findings).toHaveLength(0);
+  });
+});
+
+describe("checkPass", () => {
+  it("runs only rules for the specified pass", () => {
+    const pass1 = zinsserPasses[0]; // Cut filler
+    const result = checkPass(
+      "Each and every person should leverage the methodology herein.",
+      pass1,
+    );
+    // pass1 includes clutter, cut-filler, inflated-phrase rules
+    // "herein" is a humanize rule (pass 2), should NOT appear
+    const ruleIds = new Set(result.findings.map((f) => f.ruleId));
+    expect(ruleIds.has("zinsser-humanize")).toBe(false);
+  });
+});
+
+describe("checkAllPasses", () => {
+  it("returns results for all three passes", () => {
+    const results = checkAllPasses("Some text to analyze.");
+    expect(results).toHaveLength(3);
+    expect(results[0].pass.name).toBe("Cut filler");
+    expect(results[1].pass.name).toBe("Clarify and humanize");
+    expect(results[2].pass.name).toBe("Reader test");
+  });
+
+  it("each pass result includes escape clause", () => {
+    const results = checkAllPasses("Text.");
+    for (const { result } of results) {
+      expect(result.escapeClause).toContain("barbarous");
+    }
+  });
+});
+
+describe("allRules", () => {
+  it("includes rules from all three frameworks", () => {
+    const frameworks = new Set(allRules.map((r) => r.framework));
+    expect(frameworks).toEqual(new Set(["orwell", "zinsser", "ogilvy"]));
+  });
+
+  it("each rule has required fields", () => {
+    for (const rule of allRules) {
+      expect(rule.id).toBeTruthy();
+      expect(rule.name).toBeTruthy();
+      expect(rule.description).toBeTruthy();
+      expect(typeof rule.check).toBe("function");
+    }
+  });
+
+  it("has no duplicate rule IDs", () => {
+    const ids = allRules.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/packages/styleguide/src/__tests__/ogilvy.test.ts
+++ b/packages/styleguide/src/__tests__/ogilvy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  paragraphLengthRule,
+  clarityRule,
+  conversationalRule,
+} from "../rules/ogilvy.js";
+
+describe("paragraphLengthRule", () => {
+  it("flags paragraphs over 150 words", () => {
+    const longPara = Array(160).fill("word").join(" ");
+    const findings = paragraphLengthRule.check(longPara);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain("160 words");
+  });
+
+  it("allows short paragraphs", () => {
+    const findings = paragraphLengthRule.check("Short and sweet.\n\nAnother one.");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("checks each paragraph independently", () => {
+    const short = "This is fine.";
+    const long = Array(160).fill("word").join(" ");
+    const findings = paragraphLengthRule.check(`${short}\n\n${long}\n\n${short}`);
+    expect(findings).toHaveLength(1);
+  });
+});
+
+describe("clarityRule", () => {
+  it("flags hedging phrases", () => {
+    const findings = clarityRule.check(
+      "Perhaps you could update the config. You might want to restart.",
+    );
+    expect(findings).toHaveLength(2);
+  });
+
+  it("returns nothing for direct writing", () => {
+    const findings = clarityRule.check("Update the config. Then restart.");
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("conversationalRule", () => {
+  it("flags unnatural constructions", () => {
+    const findings = conversationalRule.check(
+      "With respect to the matter of performance, at this juncture we must act.",
+    );
+    expect(findings).toHaveLength(2);
+  });
+
+  it("suggests plain replacements", () => {
+    const findings = conversationalRule.check(
+      "The question as to whether this works is open.",
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].replacement).toBe("whether");
+  });
+});

--- a/packages/styleguide/src/__tests__/orwell.test.ts
+++ b/packages/styleguide/src/__tests__/orwell.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  deadMetaphorRule,
+  inflatedPhraseRule,
+  shortWordRule,
+  activeVoiceRule,
+  cutFillerRule,
+} from "../rules/orwell.js";
+import { inflatedPhrases } from "../phrase-table.js";
+
+describe("deadMetaphorRule", () => {
+  it("flags dead metaphors", () => {
+    const findings = deadMetaphorRule.check(
+      "We need to think outside the box to move the needle.",
+    );
+    expect(findings).toHaveLength(2);
+    expect(findings[0].matched.toLowerCase()).toBe("think outside the box");
+    expect(findings[1].matched.toLowerCase()).toBe("move the needle");
+  });
+
+  it("returns nothing for clean text", () => {
+    const findings = deadMetaphorRule.check(
+      "The system processes requests through a queue.",
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it("is case insensitive", () => {
+    const findings = deadMetaphorRule.check("A Level Playing Field is needed.");
+    expect(findings).toHaveLength(1);
+  });
+});
+
+describe("inflatedPhraseRule", () => {
+  it("flags inflated phrases with replacements", () => {
+    const findings = inflatedPhraseRule.check(
+      "We need to make contact with the team in order to take into consideration their needs.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    const callFinding = findings.find((f) =>
+      f.matched.toLowerCase() === "make contact with",
+    );
+    expect(callFinding).toBeDefined();
+    expect(callFinding!.replacement).toBe("call");
+  });
+
+  it("flags jargon words", () => {
+    const findings = inflatedPhraseRule.check(
+      "We should leverage this opportunity and utilize the framework.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    expect(findings.some((f) => f.replacement === "use")).toBe(true);
+  });
+
+  it("returns nothing for clean text", () => {
+    const findings = inflatedPhraseRule.check("Call the team about their needs.");
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("inflatedPhrases table", () => {
+  it("has entries", () => {
+    expect(inflatedPhrases.size).toBeGreaterThan(50);
+  });
+
+  it("maps inflated to plain", () => {
+    expect(inflatedPhrases.get("make contact with")).toBe("call");
+    expect(inflatedPhrases.get("utilize")).toBe("use");
+    expect(inflatedPhrases.get("due to the fact that")).toBe("because");
+  });
+});
+
+describe("shortWordRule", () => {
+  it("suggests shorter alternatives", () => {
+    const findings = shortWordRule.check(
+      "We need to demonstrate approximately numerous improvements.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    expect(findings.some((f) => f.replacement === "show")).toBe(true);
+    expect(findings.some((f) => f.replacement === "about")).toBe(true);
+  });
+});
+
+describe("activeVoiceRule", () => {
+  it("flags passive constructions", () => {
+    const findings = activeVoiceRule.check(
+      "The report was submitted by the team.",
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].matched).toBe("was submitted");
+  });
+
+  it("skips adjective exceptions", () => {
+    const findings = activeVoiceRule.check("She is interested in the project.");
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("cutFillerRule", () => {
+  it("flags filler words", () => {
+    const findings = cutFillerRule.check(
+      "It is very important to note that this is basically just a test.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(3); // very, basically, just
+  });
+
+  it("flags filler phrases", () => {
+    const findings = cutFillerRule.check(
+      "Needless to say, it goes without saying that this matters.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/styleguide/src/__tests__/zinsser.test.ts
+++ b/packages/styleguide/src/__tests__/zinsser.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  clutterRule,
+  humanizeRule,
+  sentenceLengthRule,
+  zinsserPasses,
+} from "../rules/zinsser.js";
+
+describe("clutterRule", () => {
+  it("flags redundant pairs", () => {
+    const findings = clutterRule.check("Each and every student must attend.");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].replacement).toBe("each");
+  });
+
+  it("flags wordy qualifiers", () => {
+    const findings = clutterRule.check(
+      "The system is kind of slow in terms of throughput.",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("humanizeRule", () => {
+  it("flags stiff constructions", () => {
+    const findings = humanizeRule.check(
+      "It is widely recognized that the aforementioned approach works.",
+    );
+    expect(findings).toHaveLength(2);
+  });
+
+  it("flags archaic words", () => {
+    const findings = humanizeRule.check(
+      "The values defined herein are thereby applied.",
+    );
+    expect(findings).toHaveLength(2);
+  });
+});
+
+describe("sentenceLengthRule", () => {
+  it("flags sentences over 35 words", () => {
+    const longSentence = Array(40).fill("word").join(" ") + ".";
+    const findings = sentenceLengthRule.check(longSentence);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain("40 words");
+  });
+
+  it("allows sentences under 35 words", () => {
+    const findings = sentenceLengthRule.check("This is fine.");
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("zinsserPasses", () => {
+  it("defines three passes", () => {
+    expect(zinsserPasses).toHaveLength(3);
+  });
+
+  it("pass 1 is Cut filler", () => {
+    expect(zinsserPasses[0].name).toBe("Cut filler");
+    expect(zinsserPasses[0].ruleIds.length).toBeGreaterThan(0);
+  });
+
+  it("pass 2 is Clarify and humanize", () => {
+    expect(zinsserPasses[1].name).toBe("Clarify and humanize");
+  });
+
+  it("pass 3 is Reader test", () => {
+    expect(zinsserPasses[2].name).toBe("Reader test");
+  });
+});

--- a/packages/styleguide/src/checker.ts
+++ b/packages/styleguide/src/checker.ts
@@ -17,7 +17,7 @@ export function check(document: string, styleguide: Styleguide): CheckReport {
   const results = checkPatterns(document, styleguide.rules);
   const structuralResults = checkStructural(document, styleguide.structuralRules);
 
-  const counts: Record<Severity, number> = { error: 0, warning: 0, info: 0 };
+  const counts: Record<Severity, number> = { error: 0, warning: 0, info: 0, suggestion: 0 };
   for (const r of results) {
     counts[r.severity]++;
   }
@@ -350,8 +350,12 @@ function computeScore(
   counts: Record<Severity, number>,
   _totalIssues: number,
 ): number {
-  // Weighted: errors = 1.0, warnings = 0.5, info = 0.1
-  const weighted = counts.error * 1.0 + counts.warning * 0.5 + counts.info * 0.1;
+  // Weighted: errors = 1.0, warnings = 0.5, info = 0.1, suggestions = 0.05
+  const weighted =
+    counts.error * 1.0 +
+    counts.warning * 0.5 +
+    counts.info * 0.1 +
+    counts.suggestion * 0.05;
 
   // Sigmoid-like mapping to 0-10 range
   // score = 10 * (1 - e^(-weighted/10))

--- a/packages/styleguide/src/discipline.ts
+++ b/packages/styleguide/src/discipline.ts
@@ -1,0 +1,89 @@
+/**
+ * Discipline checker that runs Orwell/Zinsser/Ogilvy language rules against text.
+ */
+
+import type { DisciplineResult, Finding, RevisionPass, DisciplineRule } from "./types.js";
+import { orwellRules } from "./rules/orwell.js";
+import { zinsserRules, zinsserPasses } from "./rules/zinsser.js";
+import { ogilvyRules } from "./rules/ogilvy.js";
+
+const ESCAPE_CLAUSE =
+  "Break any of these rules sooner than say anything outright barbarous. " +
+  "— George Orwell, rule 6";
+
+/** All rules from all three frameworks. */
+export const allRules: readonly DisciplineRule[] = [
+  ...orwellRules,
+  ...zinsserRules,
+  ...ogilvyRules,
+];
+
+/** Map of rule ID to rule, for lookup by revision passes. */
+const ruleMap = new Map<string, DisciplineRule>(allRules.map((r) => [r.id, r]));
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Run all language discipline rules against the input text.
+ * Returns structured findings sorted by position in the text.
+ */
+export function checkDiscipline(text: string): DisciplineResult {
+  const findings: Finding[] = [];
+  for (const rule of allRules) {
+    findings.push(...rule.check(text));
+  }
+  findings.sort((a, b) => a.offset - b.offset);
+  return {
+    findings,
+    wordCount: countWords(text),
+    escapeClause: ESCAPE_CLAUSE,
+  };
+}
+
+/**
+ * Run only the rules for a specific Zinsser revision pass.
+ * This allows the review pipeline to offer a three-pass revision mode.
+ */
+export function checkPass(
+  text: string,
+  pass: RevisionPass,
+): DisciplineResult {
+  const findings: Finding[] = [];
+  for (const ruleId of pass.ruleIds) {
+    const rule = ruleMap.get(ruleId);
+    if (rule) {
+      findings.push(...rule.check(text));
+    }
+  }
+  findings.sort((a, b) => a.offset - b.offset);
+  return {
+    findings,
+    wordCount: countWords(text),
+    escapeClause: ESCAPE_CLAUSE,
+  };
+}
+
+/**
+ * Run the full Zinsser three-pass revision sequence.
+ * Returns results for each pass separately so the reviewer can
+ * address one concern layer at a time.
+ */
+export function checkAllPasses(
+  text: string,
+): Array<{ pass: RevisionPass; result: DisciplineResult }> {
+  return zinsserPasses.map((pass) => ({
+    pass,
+    result: checkPass(text, pass),
+  }));
+}
+
+/**
+ * Look up the plain replacement for an inflated phrase.
+ * Returns undefined if the phrase is not in the table.
+ */
+export { inflatedPhrases } from "./phrase-table.js";
+
+/** Re-export revision passes for external use. */
+export { zinsserPasses } from "./rules/zinsser.js";

--- a/packages/styleguide/src/index.ts
+++ b/packages/styleguide/src/index.ts
@@ -1,3 +1,4 @@
+// Anti-slop checker types and API
 export type {
   Severity,
   PatternCategory,
@@ -11,3 +12,36 @@ export type {
 
 export { check } from "./checker.js";
 export { defaultStyleguide } from "./rules/index.js";
+
+// Language discipline types and API (Orwell, Zinsser, Ogilvy)
+export type {
+  Framework,
+  Finding,
+  DisciplineRule,
+  RevisionPass,
+  DisciplineResult,
+} from "./types.js";
+
+export { checkDiscipline, checkPass, checkAllPasses, allRules } from "./discipline.js";
+export { inflatedPhrases, buildPhrasePattern } from "./phrase-table.js";
+export {
+  orwellRules,
+  deadMetaphorRule,
+  inflatedPhraseRule,
+  shortWordRule,
+  activeVoiceRule,
+  cutFillerRule,
+} from "./rules/orwell.js";
+export {
+  zinsserRules,
+  zinsserPasses,
+  clutterRule,
+  humanizeRule,
+  sentenceLengthRule,
+} from "./rules/zinsser.js";
+export {
+  ogilvyRules,
+  paragraphLengthRule,
+  clarityRule,
+  conversationalRule,
+} from "./rules/ogilvy.js";

--- a/packages/styleguide/src/phrase-table.ts
+++ b/packages/styleguide/src/phrase-table.ts
@@ -1,0 +1,99 @@
+/**
+ * Inflated phrase -> plain replacement lookup table.
+ *
+ * Drawn from Orwell's "verbal false limbs" concept: writers pad out
+ * simple verbs with noun-and-verb constructions that sound important
+ * but say less. Each entry maps an inflated phrase to its plain
+ * equivalent.
+ */
+export const inflatedPhrases: ReadonlyMap<string, string> = new Map([
+  // Verbal false limbs (Orwell)
+  ["make contact with", "call"],
+  ["exhibit a tendency to", "tend to"],
+  ["serve the purpose of", "be"],
+  ["play a leading part in", "lead"],
+  ["give rise to", "cause"],
+  ["have the effect of", "make"],
+  ["take into consideration", "consider"],
+  ["take into account", "consider"],
+  ["give an account of", "describe"],
+  ["make provision for", "provide for"],
+  ["render inoperative", "break"],
+  ["militate against", "prevent"],
+  ["prove unacceptable", "reject"],
+  ["make itself felt", "affect"],
+  ["in the event that", "if"],
+  ["owing to the fact that", "because"],
+  ["due to the fact that", "because"],
+  ["in spite of the fact that", "although"],
+  ["by virtue of the fact that", "because"],
+  ["with regard to", "about"],
+  ["with respect to", "about"],
+  ["in reference to", "about"],
+  ["in relation to", "about"],
+  ["in connection with", "about"],
+  ["on the subject of", "about"],
+  ["for the purpose of", "to"],
+  ["in order to", "to"],
+  ["with a view to", "to"],
+  ["on the grounds that", "because"],
+  ["on the basis of", "by"],
+  ["in the course of", "during"],
+  ["at this point in time", "now"],
+  ["at the present time", "now"],
+  ["at the current time", "now"],
+  ["prior to", "before"],
+  ["subsequent to", "after"],
+  ["in the near future", "soon"],
+  ["a large number of", "many"],
+  ["a sufficient number of", "enough"],
+  ["the vast majority of", "most"],
+  ["a considerable amount of", "much"],
+  ["in the absence of", "without"],
+  ["is in a position to", "can"],
+  ["has the capacity to", "can"],
+  ["has the ability to", "can"],
+  ["it is necessary that", "must"],
+  ["it is important that", "should"],
+
+  // Jargon and pretentious diction (Orwell)
+  ["utilize", "use"],
+  ["leverage", "use"],
+  ["facilitate", "help"],
+  ["endeavor", "try"],
+  ["commence", "start"],
+  ["terminate", "end"],
+  ["ascertain", "find out"],
+  ["ameliorate", "improve"],
+  ["effectuate", "carry out"],
+  ["promulgate", "announce"],
+  ["implement a solution", "fix"],
+  ["interface with", "talk to"],
+  ["impact negatively", "hurt"],
+  ["impact positively", "help"],
+  ["optimize", "improve"],
+  ["finalize", "finish"],
+  ["conceptualize", "think of"],
+  ["incentivize", "encourage"],
+  ["operationalize", "put into practice"],
+  ["paradigm shift", "change"],
+  ["synergy", "cooperation"],
+  ["bandwidth", "time"],
+  ["low-hanging fruit", "easy win"],
+  ["move the needle", "make progress"],
+  ["circle back", "revisit"],
+  ["deep dive", "close look"],
+]);
+
+/**
+ * Build a case-insensitive regex that matches any inflated phrase.
+ * Word boundaries ensure we don't match partial words.
+ */
+export function buildPhrasePattern(): RegExp {
+  const escaped = [...inflatedPhrases.keys()].map((phrase) =>
+    phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+  );
+  // Sort longest-first so longer phrases match before shorter substrings.
+  escaped.sort((a, b) => b.length - a.length);
+  return new RegExp(`\\b(${escaped.join("|")})\\b`, "gi");
+}

--- a/packages/styleguide/src/rules/index.ts
+++ b/packages/styleguide/src/rules/index.ts
@@ -14,3 +14,12 @@ export const defaultStyleguide: Styleguide = {
   rules: [...bannedPhrases, ...overusedWords, ...styleRules],
   structuralRules,
 };
+
+// Language discipline rule re-exports
+export { orwellRules } from "./orwell.js";
+export { zinsserRules, zinsserPasses } from "./zinsser.js";
+export { ogilvyRules } from "./ogilvy.js";
+
+export * from "./orwell.js";
+export * from "./zinsser.js";
+export * from "./ogilvy.js";

--- a/packages/styleguide/src/rules/ogilvy.ts
+++ b/packages/styleguide/src/rules/ogilvy.ts
@@ -1,0 +1,155 @@
+/**
+ * Ogilvy's writing-as-action principles.
+ *
+ * Core tenets:
+ * - Write the way you talk.
+ * - Short words, short sentences, short paragraphs.
+ * - Be crystal clear about what you want the reader to do.
+ */
+
+import type { Finding, DisciplineRule } from "../types.js";
+
+// --- Paragraph length ---
+const MAX_PARAGRAPH_WORDS = 150;
+
+/** Flags paragraphs over 150 words — Ogilvy demands short paragraphs. */
+export const paragraphLengthRule: DisciplineRule= {
+  id: "ogilvy-paragraph-length",
+  name: "Short paragraphs",
+  description:
+    "Flags paragraphs over 150 words. Ogilvy: short words, short sentences, short paragraphs.",
+  framework: "ogilvy",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    // Split on blank lines (two+ consecutive newlines).
+    const paragraphs = text.split(/\n\s*\n/);
+    let offset = 0;
+    for (const para of paragraphs) {
+      const trimmed = para.trim();
+      if (!trimmed) {
+        offset += para.length + 1;
+        continue;
+      }
+      const words = trimmed.split(/\s+/).filter(Boolean);
+      if (words.length > MAX_PARAGRAPH_WORDS) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Long paragraph (${words.length} words). Break it up — aim for under ${MAX_PARAGRAPH_WORDS} words.`,
+          matched:
+            trimmed.slice(0, 80) + (trimmed.length > 80 ? "..." : ""),
+          offset: text.indexOf(trimmed, offset),
+          length: trimmed.length,
+        });
+      }
+      offset += para.length + 1;
+    }
+    return findings;
+  },
+};
+
+// --- Clarity / call-to-action check ---
+
+/**
+ * Hedging phrases that undermine clarity about what the reader should do.
+ * Ogilvy insists on being crystal clear about the desired action.
+ */
+const hedgingPhrases: ReadonlyArray<[RegExp, string]> = [
+  [/\bperhaps you could\b/gi, "tell them what to do"],
+  [/\byou might want to\b/gi, "tell them what to do"],
+  [/\bit might be worth\b/gi, "say whether it is or isn't"],
+  [/\bconsider maybe\b/gi, "just say what to consider"],
+  [/\byou may wish to\b/gi, "tell them what to do"],
+  [/\bit would be advisable\b/gi, "say what to do directly"],
+  [/\bone option would be\b/gi, "recommend the best option"],
+  [/\bit could be argued\b/gi, "make the argument or don't"],
+  [/\bwe should probably\b/gi, "commit: should or shouldn't?"],
+  [/\bthere is a possibility\b/gi, "state the possibility directly"],
+  [/\bit remains to be seen\b/gi, "say what you don't know yet"],
+];
+
+/** Ogilvy clarity check: does the writing make clear what the reader should do? */
+export const clarityRule: DisciplineRule= {
+  id: "ogilvy-clarity",
+  name: "Clarity check",
+  description:
+    "Flags hedging phrases that obscure what the reader should do. Ogilvy: be crystal clear about the desired action.",
+  framework: "ogilvy",
+  severity: "warning",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    for (const [pattern, suggestion] of hedgingPhrases) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Hedging: "${match[0]}" — ${suggestion}.`,
+          matched: match[0],
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+// --- Conversational tone ---
+/**
+ * Detects constructions that nobody would say aloud.
+ * Ogilvy: write the way you talk.
+ */
+const unnaturalConstructions: ReadonlyArray<[RegExp, string]> = [
+  [/\bwith respect to the matter of\b/gi, "about"],
+  [/\bin light of the foregoing\b/gi, "so"],
+  [/\bit should be borne in mind that\b/gi, "remember"],
+  [/\bthe question as to whether\b/gi, "whether"],
+  [/\bthere is no doubt but that\b/gi, "no doubt"],
+  [/\bin a very real sense\b/gi, "cut entirely"],
+  [/\bfor all intents and purposes\b/gi, "in effect"],
+  [/\bit is incumbent upon\b/gi, "must"],
+  [/\bat this juncture\b/gi, "now"],
+  [/\bthe foregoing notwithstanding\b/gi, "still"],
+];
+
+/** Ogilvy conversational tone: write the way you talk. */
+export const conversationalRule: DisciplineRule= {
+  id: "ogilvy-conversational",
+  name: "Write the way you talk",
+  description:
+    "Flags constructions nobody would say in conversation. Ogilvy: write the way you talk.",
+  framework: "ogilvy",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    for (const [pattern, suggestion] of unnaturalConstructions) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Unnatural: "${match[0]}" — try "${suggestion}" instead.`,
+          matched: match[0],
+          replacement: suggestion,
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+/** All Ogilvy rules. */
+export const ogilvyRules: readonly DisciplineRule[] = [
+  paragraphLengthRule,
+  clarityRule,
+  conversationalRule,
+];

--- a/packages/styleguide/src/rules/orwell.ts
+++ b/packages/styleguide/src/rules/orwell.ts
@@ -1,0 +1,305 @@
+/**
+ * Orwell's language discipline rules from "Politics and the English Language" (1946).
+ *
+ * Six rules:
+ * 1. Never use a metaphor, simile or other figure of speech which you are used to seeing in print.
+ * 2. Never use a long word where a short one will do.
+ * 3. If it is possible to cut a word out, always cut it out.
+ * 4. Never use the passive where you can use the active.
+ * 5. Never use a foreign phrase, a scientific word or a jargon word if you can think of an everyday English equivalent.
+ * 6. Break any of these rules sooner than say anything outright barbarous.
+ */
+
+import type { Finding, DisciplineRule } from "../types.js";
+import { buildPhrasePattern, inflatedPhrases } from "../phrase-table.js";
+
+// --- Dead metaphors ---
+// Common dead metaphors where the physical image is lost.
+const deadMetaphors: readonly string[] = [
+  "level playing field",
+  "move the goalposts",
+  "toe the line",
+  "run it up the flagpole",
+  "leave no stone unturned",
+  "take the bull by the horns",
+  "throw the baby out with the bathwater",
+  "think outside the box",
+  "push the envelope",
+  "at the end of the day",
+  "the bottom line",
+  "behind the curve",
+  "ahead of the curve",
+  "raise the bar",
+  "tip of the iceberg",
+  "on the same page",
+  "low-hanging fruit",
+  "move the needle",
+  "open the floodgates",
+  "a perfect storm",
+  "the elephant in the room",
+  "a slippery slope",
+  "kick the can down the road",
+  "double-edged sword",
+  "reinvent the wheel",
+  "burning the midnight oil",
+  "barking up the wrong tree",
+  "break the ice",
+  "hit the nail on the head",
+  "back to the drawing board",
+  "cutting edge",
+  "state of the art",
+  "game-changer",
+  "deep dive",
+  "circle back",
+  "peel back the onion",
+  "boil the ocean",
+  "swim lane",
+  "paradigm shift",
+];
+
+function buildDeadMetaphorPattern(): RegExp {
+  const escaped = deadMetaphors.map((m) =>
+    m.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+  );
+  escaped.sort((a, b) => b.length - a.length);
+  return new RegExp(`\\b(${escaped.join("|")})\\b`, "gi");
+}
+
+/** Rule 1: Dead metaphor test — "Can you picture the physical scene?" */
+export const deadMetaphorRule: DisciplineRule= {
+  id: "orwell-dead-metaphor",
+  name: "Dead metaphor test",
+  description:
+    'Flags dead metaphors where the physical image is lost. Ask: "Can you picture the physical scene?" If not, replace it.',
+  framework: "orwell",
+  severity: "warning",
+  check(text: string): Finding[] {
+    const pattern = buildDeadMetaphorPattern();
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      findings.push({
+        ruleId: this.id,
+        framework: this.framework,
+        severity: this.severity,
+        message: `Dead metaphor: "${match[0]}". Can you picture the physical scene? If not, replace with a fresh image or plain language.`,
+        matched: match[0],
+        offset: match.index,
+        length: match[0].length,
+      });
+    }
+    return findings;
+  },
+};
+
+/** Rule 2 & 5: Verbal false limbs and jargon — inflated phrase lookup. */
+export const inflatedPhraseRule: DisciplineRule= {
+  id: "orwell-inflated-phrase",
+  name: "Verbal false limbs / jargon",
+  description:
+    "Flags inflated phrases and jargon that have simpler everyday equivalents.",
+  framework: "orwell",
+  severity: "warning",
+  check(text: string): Finding[] {
+    const pattern = buildPhrasePattern();
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const plain = inflatedPhrases.get(match[0].toLowerCase());
+      findings.push({
+        ruleId: this.id,
+        framework: this.framework,
+        severity: this.severity,
+        message: `Inflated phrase: "${match[0]}" -> "${plain}".`,
+        matched: match[0],
+        replacement: plain,
+        offset: match.index,
+        length: match[0].length,
+      });
+    }
+    return findings;
+  },
+};
+
+// --- Long words where short ones will do ---
+// Pairs: [long word pattern, short replacement].
+const longWordReplacements: ReadonlyArray<[RegExp, string]> = [
+  [/\badditionally\b/gi, "also"],
+  [/\bconsequently\b/gi, "so"],
+  [/\bfurthermore\b/gi, "also"],
+  [/\bnevertheless\b/gi, "still"],
+  [/\bnotwithstanding\b/gi, "despite"],
+  [/\bapproximately\b/gi, "about"],
+  [/\bsubsequently\b/gi, "then"],
+  [/\bmethodology\b/gi, "method"],
+  [/\bdemonstrate\b/gi, "show"],
+  [/\bsufficient\b/gi, "enough"],
+  [/\bnumerous\b/gi, "many"],
+  [/\bpurchase\b/gi, "buy"],
+  [/\binquire\b/gi, "ask"],
+  [/\bassist\b/gi, "help"],
+  [/\battempt\b/gi, "try"],
+  [/\brequire\b/gi, "need"],
+  [/\bmodify\b/gi, "change"],
+  [/\bobtain\b/gi, "get"],
+  [/\binitial\b/gi, "first"],
+  [/\bremaining\b/gi, "left"],
+  [/\bcurrently\b/gi, "now"],
+  [/\bpreviously\b/gi, "before"],
+];
+
+/** Rule 2: Short word preference. */
+export const shortWordRule: DisciplineRule= {
+  id: "orwell-short-word",
+  name: "Short word preference",
+  description: "Never use a long word where a short one will do.",
+  framework: "orwell",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    for (const [pattern, replacement] of longWordReplacements) {
+      let match: RegExpExecArray | null;
+      // Reset lastIndex for each pattern since we reuse them.
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Consider shorter word: "${match[0]}" -> "${replacement}".`,
+          matched: match[0],
+          replacement,
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+// --- Passive voice detection ---
+// Simple heuristic: auxiliary "be" forms + past participle pattern (word ending in -ed).
+// This won't catch irregular past participles, but avoids false positives.
+const passivePattern =
+  /\b(is|are|was|were|be|been|being)\s+(\w+ed)\b/gi;
+
+/** Rule 4: Active voice preference. */
+export const activeVoiceRule: DisciplineRule= {
+  id: "orwell-active-voice",
+  name: "Active voice preference",
+  description: "Prefer active over passive construction.",
+  framework: "orwell",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    let match: RegExpExecArray | null;
+    passivePattern.lastIndex = 0;
+    while ((match = passivePattern.exec(text)) !== null) {
+      // Skip common false positives where the -ed word is typically an adjective.
+      const participle = match[2].toLowerCase();
+      if (adjectiveExceptions.has(participle)) continue;
+      findings.push({
+        ruleId: this.id,
+        framework: this.framework,
+        severity: this.severity,
+        message: `Possible passive voice: "${match[0]}". Consider rewriting in active voice.`,
+        matched: match[0],
+        offset: match.index,
+        length: match[0].length,
+      });
+    }
+    return findings;
+  },
+};
+
+const adjectiveExceptions = new Set([
+  "interested",
+  "excited",
+  "pleased",
+  "tired",
+  "bored",
+  "concerned",
+  "surprised",
+  "confused",
+  "satisfied",
+  "disappointed",
+  "embarrassed",
+  "overwhelmed",
+  "married",
+  "related",
+  "based",
+  "focused",
+  "dedicated",
+  "committed",
+  "limited",
+  "required",
+  "expected",
+  "supposed",
+  "allowed",
+  "located",
+  "designed",
+  "intended",
+]);
+
+// --- Filler words and phrases (Rule 3: Cut what adds nothing) ---
+const fillerPatterns: ReadonlyArray<[RegExp, string]> = [
+  [/\bvery\b/gi, "very"],
+  [/\breally\b/gi, "really"],
+  [/\bquite\b/gi, "quite"],
+  [/\bjust\b/gi, "just"],
+  [/\bsimply\b/gi, "simply"],
+  [/\bbasically\b/gi, "basically"],
+  [/\bactually\b/gi, "actually"],
+  [/\bessentially\b/gi, "essentially"],
+  [/\bliterally\b/gi, "literally"],
+  [/\bdefinitely\b/gi, "definitely"],
+  [/\babsolutely\b/gi, "absolutely"],
+  [/\bit should be noted that\b/gi, "it should be noted that"],
+  [/\bit is worth noting that\b/gi, "it is worth noting that"],
+  [/\bit is important to note that\b/gi, "it is important to note that"],
+  [/\bneedless to say\b/gi, "needless to say"],
+  [/\bit goes without saying\b/gi, "it goes without saying"],
+  [/\bas a matter of fact\b/gi, "as a matter of fact"],
+  [/\bin my opinion\b/gi, "in my opinion"],
+  [/\ball things considered\b/gi, "all things considered"],
+  [/\bfirst and foremost\b/gi, "first and foremost"],
+];
+
+/** Rule 3: Cut filler — if a word doesn't earn its place, remove it. */
+export const cutFillerRule: DisciplineRule= {
+  id: "orwell-cut-filler",
+  name: "Cut what adds nothing",
+  description:
+    "Flags filler words and phrases that can usually be removed without changing meaning.",
+  framework: "orwell",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    for (const [pattern, label] of fillerPatterns) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Filler: "${label}" can probably be cut without losing meaning.`,
+          matched: match[0],
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+/** All Orwell rules. */
+export const orwellRules: readonly DisciplineRule[] = [
+  deadMetaphorRule,
+  inflatedPhraseRule,
+  shortWordRule,
+  activeVoiceRule,
+  cutFillerRule,
+];

--- a/packages/styleguide/src/rules/zinsser.ts
+++ b/packages/styleguide/src/rules/zinsser.ts
@@ -1,0 +1,222 @@
+/**
+ * Zinsser's clutter removal system from "On Writing Well".
+ *
+ * Three revision passes:
+ * 1. Cut filler — aim for 20-30% word reduction.
+ * 2. Clarify and humanize — "Would I say this aloud to a smart friend?"
+ * 3. Reader test — read aloud, fix stumbles, trim opening and closing.
+ */
+
+import type { Finding, RevisionPass, DisciplineRule } from "../types.js";
+
+// --- Pass 1: Clutter detection ---
+
+/** Redundant pairs where one word does the work of two. */
+const redundantPairs: ReadonlyArray<[RegExp, string]> = [
+  [/\beach and every\b/gi, "each"],
+  [/\bfirst and foremost\b/gi, "first"],
+  [/\bany and all\b/gi, "all"],
+  [/\bvarious and sundry\b/gi, "various"],
+  [/\bhope and trust\b/gi, "trust"],
+  [/\bnull and void\b/gi, "void"],
+  [/\bfull and complete\b/gi, "complete"],
+  [/\btrue and accurate\b/gi, "accurate"],
+  [/\bbasic and fundamental\b/gi, "fundamental"],
+  [/\bplain and simple\b/gi, "simple"],
+];
+
+/** Wordy qualifiers that add bulk without meaning. */
+const wordyQualifiers: ReadonlyArray<[RegExp, string]> = [
+  [/\ba bit\b/gi, "a bit"],
+  [/\bkind of\b/gi, "kind of"],
+  [/\bsort of\b/gi, "sort of"],
+  [/\btype of\b/gi, "type of"],
+  [/\bin terms of\b/gi, "in terms of"],
+  [/\bthe fact that\b/gi, "the fact that"],
+  [/\bwhat I mean is\b/gi, "what I mean is"],
+  [/\bwhat I'm saying is\b/gi, "what I'm saying is"],
+  [/\bif you will\b/gi, "if you will"],
+  [/\bas it were\b/gi, "as it were"],
+  [/\bso to speak\b/gi, "so to speak"],
+];
+
+/** Pass 1 rule: Cut clutter. */
+export const clutterRule: DisciplineRule= {
+  id: "zinsser-clutter",
+  name: "Cut the clutter",
+  description:
+    "Flags redundant pairs, wordy qualifiers, and padded phrases. Aim for 20-30% word reduction.",
+  framework: "zinsser",
+  severity: "warning",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+
+    for (const [pattern, replacement] of redundantPairs) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Redundant pair: "${match[0]}" -> "${replacement}".`,
+          matched: match[0],
+          replacement,
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+
+    for (const [pattern, label] of wordyQualifiers) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Wordy qualifier: "${label}" — can you cut it?`,
+          matched: match[0],
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+
+    return findings;
+  },
+};
+
+// --- Pass 2: Humanize check ---
+
+/**
+ * Detects overly formal or stiff constructions that fail the
+ * "Would I say this aloud to a smart friend?" test.
+ */
+const stiffConstructions: ReadonlyArray<[RegExp, string]> = [
+  [/\bit is widely recognized that\b/gi, "drop — just state the claim"],
+  [/\bit has been established that\b/gi, "drop — just state the claim"],
+  [/\bone might argue that\b/gi, "drop — just state the argument"],
+  [/\bit can be observed that\b/gi, "drop — just state the observation"],
+  [/\bit is generally accepted that\b/gi, "drop — just state the claim"],
+  [
+    /\bthe aforementioned\b/gi,
+    'use a specific reference ("that module", "the parser")',
+  ],
+  [/\bherein\b/gi, "here"],
+  [/\btherein\b/gi, "there"],
+  [/\bwherein\b/gi, "where"],
+  [/\bthereby\b/gi, "so"],
+  [/\bhitherto\b/gi, "until now"],
+  [/\bnotwithstanding\b/gi, "despite"],
+  [/\binasmuch as\b/gi, "since"],
+  [/\binsofar as\b/gi, "as far as"],
+];
+
+/** Pass 2 rule: Humanize stiff writing. */
+export const humanizeRule: DisciplineRule= {
+  id: "zinsser-humanize",
+  name: "Clarify and humanize",
+  description:
+    'Flags overly formal constructions. Test: "Would I say this aloud to a smart friend?"',
+  framework: "zinsser",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    for (const [pattern, suggestion] of stiffConstructions) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Stiff construction: "${match[0]}" — ${suggestion}.`,
+          matched: match[0],
+          offset: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+// --- Pass 3: Reader test (structural checks) ---
+
+/** Sentence length threshold (words). Sentences over this tend to cause stumbles. */
+const MAX_SENTENCE_WORDS = 35;
+
+/** Pass 3 rule: Long sentence detection (read-aloud stumble proxy). */
+export const sentenceLengthRule: DisciplineRule= {
+  id: "zinsser-sentence-length",
+  name: "Reader test: sentence length",
+  description:
+    "Flags sentences over 35 words — a proxy for the read-aloud stumble test.",
+  framework: "zinsser",
+  severity: "suggestion",
+  check(text: string): Finding[] {
+    const findings: Finding[] = [];
+    // Split on sentence-ending punctuation followed by space or end.
+    const sentences = text.split(/(?<=[.!?])\s+/);
+    let offset = 0;
+    for (const sentence of sentences) {
+      const words = sentence.trim().split(/\s+/).filter(Boolean);
+      if (words.length > MAX_SENTENCE_WORDS) {
+        findings.push({
+          ruleId: this.id,
+          framework: this.framework,
+          severity: this.severity,
+          message: `Long sentence (${words.length} words). Try breaking it up — read it aloud and split where you pause.`,
+          matched: sentence.slice(0, 80) + (sentence.length > 80 ? "..." : ""),
+          offset,
+          length: sentence.length,
+        });
+      }
+      offset += sentence.length + 1; // +1 for the split separator
+    }
+    return findings;
+  },
+};
+
+/** All Zinsser rules. */
+export const zinsserRules: readonly DisciplineRule[] = [
+  clutterRule,
+  humanizeRule,
+  sentenceLengthRule,
+];
+
+/**
+ * Zinsser's three-pass revision structure.
+ * Each pass specifies which rules to apply, forming a progressive
+ * revision mode option for the review pipeline.
+ */
+export const zinsserPasses: readonly RevisionPass[] = [
+  {
+    id: "zinsser-pass-1",
+    name: "Cut filler",
+    goal: "Aim for 20-30% word reduction. Remove every word that doesn't earn its place.",
+    ruleIds: [
+      "zinsser-clutter",
+      "orwell-cut-filler",
+      "orwell-inflated-phrase",
+    ],
+  },
+  {
+    id: "zinsser-pass-2",
+    name: "Clarify and humanize",
+    goal: 'Would you say this aloud to a smart friend? Replace stiff constructions with natural language.',
+    ruleIds: [
+      "zinsser-humanize",
+      "orwell-active-voice",
+      "orwell-short-word",
+    ],
+  },
+  {
+    id: "zinsser-pass-3",
+    name: "Reader test",
+    goal: "Read aloud. Fix stumbles. Trim opening and closing. Check sentence length.",
+    ruleIds: ["zinsser-sentence-length", "orwell-dead-metaphor"],
+  },
+];

--- a/packages/styleguide/src/types.ts
+++ b/packages/styleguide/src/types.ts
@@ -4,8 +4,9 @@
  * - error: Kill-on-sight. Always wrong in any context (e.g., "delve", chatbot artifacts).
  * - warning: Suspicious in clusters. One occurrence is fine; multiple indicate AI slop.
  * - info: Style suggestions. Not wrong per se but worth flagging for author awareness.
+ * - suggestion: Language discipline suggestion from Orwell/Zinsser/Ogilvy rules.
  */
-export type Severity = "error" | "warning" | "info";
+export type Severity = "error" | "warning" | "info" | "suggestion";
 
 /**
  * Categories of AI writing patterns.
@@ -134,4 +135,64 @@ export interface CheckReport {
   results: CheckResult[];
   /** Structural analysis results */
   structuralResults: StructuralCheckResult[];
+}
+
+// -- Language discipline types (Orwell, Zinsser, Ogilvy) --
+
+/** Framework source for a language discipline rule. */
+export type Framework = "orwell" | "zinsser" | "ogilvy";
+
+/** A single finding produced by a discipline rule check. */
+export interface Finding {
+  ruleId: string;
+  framework: Framework;
+  severity: Severity;
+  message: string;
+  /** The matched text that triggered the finding. */
+  matched: string;
+  /** Suggested replacement, if applicable. */
+  replacement?: string;
+  /** Character offset in the input text. */
+  offset: number;
+  /** Length of the matched span. */
+  length: number;
+}
+
+/** A reviewable language discipline rule with a testable check function. */
+export interface DisciplineRule {
+  id: string;
+  name: string;
+  description: string;
+  framework: Framework;
+  severity: Severity;
+  /**
+   * Check the input text and return any findings.
+   * Rules should return an empty array if no issues are found.
+   */
+  check(text: string): Finding[];
+}
+
+/**
+ * Zinsser's three revision passes, usable as a revision mode option.
+ * Each pass has a name, goal, and set of rules to apply.
+ */
+export interface RevisionPass {
+  id: string;
+  name: string;
+  goal: string;
+  /** Rule IDs to apply during this pass. */
+  ruleIds: string[];
+}
+
+/** Result of running the discipline checker against a document. */
+export interface DisciplineResult {
+  findings: Finding[];
+  /** Total number of words in the input. */
+  wordCount: number;
+  /**
+   * Escape clause reminder: "Break any rule rather than write something
+   * barbarous." Every result carries this so reviewers remember that
+   * mechanical rules are guidelines, not absolutes.
+   */
+  escapeClause: string;
 }

--- a/packages/styleguide/tsconfig.json
+++ b/packages/styleguide/tsconfig.json
@@ -11,5 +11,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__", "dist"]
 }

--- a/packages/styleguide/vitest.config.ts
+++ b/packages/styleguide/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
Adds the `@draftwell/styleguide` package implementing mechanical language discipline checks drawn from Orwell, Zinsser, and Ogilvy. These become structured review criteria in draftwell's review pipeline.

## Changes
- **Types** (`types.ts`): `Rule`, `Finding`, `RevisionPass`, `CheckResult` interfaces with escape clause
- **Phrase table** (`phrase-table.ts`): 70+ inflated-to-plain phrase mappings (Orwell's verbal false limbs + jargon)
- **Orwell rules** (`rules/orwell.ts`): Dead metaphor test, inflated phrase checker, short word preference, passive voice detection, filler word flagging
- **Zinsser rules** (`rules/zinsser.ts`): Clutter detection (redundant pairs, wordy qualifiers), humanize check, sentence length check. Three-pass revision structure (cut filler → clarify/humanize → reader test)
- **Ogilvy rules** (`rules/ogilvy.ts`): Clarity/call-to-action check (hedging detection), paragraph length, conversational tone check
- **Checker** (`checker.ts`): `check()` runs all rules, `checkPass()` runs a single Zinsser pass, `checkAllPasses()` runs the full three-pass sequence
- **Tests**: 41 tests across 4 test files covering all rules and the checker

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Encode Orwell's rules as reviewable criteria with testable conditions | ✅ | 5 rules with `check()` functions returning positioned findings |
| Implement inflated→plain phrase lookup table | ✅ | 70+ entries in `phrase-table.ts`, used by `inflatedPhraseRule` |
| Add Zinsser's three-pass structure as revision mode | ✅ | `zinsserPasses` array + `checkPass()`/`checkAllPasses()` functions |
| Include dead metaphor test as review dimension | ✅ | `deadMetaphorRule` with 40 common dead metaphors |
| Include Ogilvy clarity check | ✅ | `clarityRule` flags hedging phrases that obscure reader action |
| All rules include escape clause | ✅ | Every `CheckResult` carries Orwell's "Break any rule rather than say anything barbarous" |

## Test Plan
- `npx vitest run` — 41 tests pass across orwell, zinsser, ogilvy, and checker test suites
- `npx tsc --noEmit` — TypeScript compiles cleanly with strict mode

Closes #9