### PR TITLE
fix: exclude .loom/worktrees/ from vitest test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
     include: ["**/__tests__/**/*.test.{ts,tsx}", "**/*.test.{ts,tsx}"],
+    exclude: ["**/node_modules/**", ".loom/worktrees/**"],
     testTimeout: 10000,
     hookTimeout: 10000,
     coverage: {


### PR DESCRIPTION
## Summary

- Adds `.loom/worktrees/**` to vitest `test.exclude` array so test discovery skips git worktree directories
- Fixes 27 false test failures caused by worktree files matching the `**/__tests__/**/*.test.{ts,tsx}` include pattern

Closes #33

## Test plan

- [x] `pnpm test --run` confirms no worktree tests are discovered
- [x] All 137 main-tree tests pass
- [ ] Verify `pnpm test` exit code is clean on main after merge (excluding pre-existing empty test suite issues in `packages/review-panel/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)