### PR TITLE
feat: add calibrated scoring with writer/judge model separation

### DIFF
--- a/migrations/0002_score_tracking.sql
+++ b/migrations/0002_score_tracking.sql
@@ -1,0 +1,64 @@
+-- Score tracking for calibrated document evaluation
+-- Logs scores across revision cycles to track improvement trajectory
+
+-- Document scores (one entry per scoring session)
+CREATE TABLE IF NOT EXISTS document_scores (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL,
+  revision_number INTEGER NOT NULL,
+  overall_score REAL NOT NULL,
+  model TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+);
+
+-- Dimension scores (one entry per dimension per scoring session)
+CREATE TABLE IF NOT EXISTS dimension_scores (
+  id TEXT PRIMARY KEY,
+  document_score_id TEXT NOT NULL,
+  dimension_id TEXT NOT NULL,
+  score INTEGER NOT NULL CHECK (score BETWEEN 1 AND 10),
+  justification TEXT,
+  FOREIGN KEY (document_score_id) REFERENCES document_scores(id) ON DELETE CASCADE
+);
+
+-- Dimension weaknesses with quoted evidence
+CREATE TABLE IF NOT EXISTS dimension_weaknesses (
+  id TEXT PRIMARY KEY,
+  dimension_score_id TEXT NOT NULL,
+  description TEXT NOT NULL,
+  evidence TEXT NOT NULL,
+  FOREIGN KEY (dimension_score_id) REFERENCES dimension_scores(id) ON DELETE CASCADE
+);
+
+-- Elo ratings for document version comparisons
+CREATE TABLE IF NOT EXISTS elo_ratings (
+  document_id TEXT NOT NULL,
+  revision_number INTEGER NOT NULL,
+  rating INTEGER NOT NULL DEFAULT 1500,
+  matches_played INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (document_id, revision_number),
+  FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+);
+
+-- Comparison results (head-to-head matchups)
+CREATE TABLE IF NOT EXISTS comparisons (
+  id TEXT PRIMARY KEY,
+  version_a_document_id TEXT NOT NULL,
+  version_a_revision INTEGER NOT NULL,
+  version_b_document_id TEXT NOT NULL,
+  version_b_revision INTEGER NOT NULL,
+  winner TEXT NOT NULL CHECK (winner IN ('A', 'B')),
+  reasoning TEXT,
+  model TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_document_scores_doc ON document_scores(document_id);
+CREATE INDEX IF NOT EXISTS idx_document_scores_doc_rev ON document_scores(document_id, revision_number);
+CREATE INDEX IF NOT EXISTS idx_dimension_scores_parent ON dimension_scores(document_score_id);
+CREATE INDEX IF NOT EXISTS idx_dimension_weaknesses_parent ON dimension_weaknesses(dimension_score_id);
+CREATE INDEX IF NOT EXISTS idx_comparisons_version_a ON comparisons(version_a_document_id, version_a_revision);
+CREATE INDEX IF NOT EXISTS idx_comparisons_version_b ON comparisons(version_b_document_id, version_b_revision);

--- a/packages/review-panel/src/comparison.ts
+++ b/packages/review-panel/src/comparison.ts
@@ -1,0 +1,251 @@
+/**
+ * Head-to-head comparison module for document versions.
+ *
+ * Key insight from autonovel: Absolute 1-10 scoring "collapses to a 2-point
+ * band regardless of rubric calibration." Forced-choice pairwise comparison
+ * produces more reliable rankings. This module implements Elo-style ranking
+ * from pairwise comparisons.
+ */
+
+import type {
+  ComparisonResult,
+  EloRating,
+  ScoringDimension,
+} from "./types.js";
+import { SCORING_DIMENSIONS } from "./scoring.js";
+
+/** Default Elo rating for new documents */
+const DEFAULT_ELO = 1500;
+
+/** K-factor controls how much ratings change per match */
+const K_FACTOR = 32;
+
+/**
+ * Build a forced-choice comparison prompt for two document versions.
+ * The model must pick a winner — no ties allowed.
+ */
+export function buildComparisonPrompt(
+  documentA: string,
+  documentB: string,
+  dimensions: ScoringDimension[] = SCORING_DIMENSIONS,
+): string {
+  const dimensionList = dimensions
+    .map((d) => `- **${d.name}** (${d.id}): ${d.description}`)
+    .join("\n");
+
+  return `You are comparing two versions of a document. You MUST choose a winner — no ties.
+
+COMPARISON DIMENSIONS:
+${dimensionList}
+
+INSTRUCTIONS:
+1. Read both versions carefully.
+2. For each dimension, decide which version is better and explain why in one sentence.
+3. Choose an overall winner based on which version is better across all dimensions.
+4. You MUST pick a winner. "They are equal" is not an option. If they seem close, identify the tiebreaker dimension and use it.
+
+RESPONSE FORMAT:
+Respond with a JSON object (no markdown fences):
+{
+  "dimensionWins": [
+    {
+      "dimensionId": "<dimension id>",
+      "winner": "A" or "B",
+      "reasoning": "<one sentence explaining why>"
+    }
+  ],
+  "winner": "A" or "B",
+  "reasoning": "<overall reasoning for the choice>"
+}
+
+---
+
+VERSION A:
+
+${documentA}
+
+---
+
+VERSION B:
+
+${documentB}`;
+}
+
+/**
+ * Parse the model's comparison response.
+ */
+export function parseComparisonResponse(
+  raw: string,
+): { winner: "A" | "B"; dimensionWins: ComparisonResult["dimensionWins"]; reasoning: string } | null {
+  const cleaned = raw.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "");
+
+  try {
+    const parsed = JSON.parse(cleaned);
+
+    const winner = parsed.winner === "A" || parsed.winner === "B"
+      ? parsed.winner
+      : null;
+
+    if (!winner) return null;
+
+    const dimensionWins: ComparisonResult["dimensionWins"] = [];
+    if (Array.isArray(parsed.dimensionWins)) {
+      for (const dw of parsed.dimensionWins) {
+        if (
+          typeof dw.dimensionId === "string" &&
+          (dw.winner === "A" || dw.winner === "B") &&
+          typeof dw.reasoning === "string"
+        ) {
+          dimensionWins.push({
+            dimensionId: dw.dimensionId,
+            winner: dw.winner,
+            reasoning: dw.reasoning.trim(),
+          });
+        }
+      }
+    }
+
+    return {
+      winner,
+      dimensionWins,
+      reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning.trim() : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a head-to-head comparison between two document versions.
+ */
+export async function compareDocuments(
+  versionA: { documentId: string; revisionNumber: number; content: string },
+  versionB: { documentId: string; revisionNumber: number; content: string },
+  callModel: (prompt: string) => Promise<string>,
+  options?: {
+    dimensions?: ScoringDimension[];
+    model?: string;
+  },
+): Promise<ComparisonResult> {
+  const dimensions = options?.dimensions ?? SCORING_DIMENSIONS;
+  const prompt = buildComparisonPrompt(versionA.content, versionB.content, dimensions);
+  const raw = await callModel(prompt);
+  const parsed = parseComparisonResponse(raw);
+
+  if (!parsed) {
+    throw new Error("Failed to parse comparison response — model did not return valid JSON with a winner");
+  }
+
+  return {
+    versionA: { documentId: versionA.documentId, revisionNumber: versionA.revisionNumber },
+    versionB: { documentId: versionB.documentId, revisionNumber: versionB.revisionNumber },
+    winner: parsed.winner,
+    dimensionWins: parsed.dimensionWins,
+    reasoning: parsed.reasoning,
+    model: options?.model ?? "unknown",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// --- Elo Rating System ---
+
+/**
+ * Calculate expected win probability for player A against player B.
+ */
+export function expectedScore(ratingA: number, ratingB: number): number {
+  return 1 / (1 + Math.pow(10, (ratingB - ratingA) / 400));
+}
+
+/**
+ * Update Elo ratings after a match.
+ * Returns new ratings for both players.
+ */
+export function updateEloRatings(
+  ratingA: number,
+  ratingB: number,
+  winner: "A" | "B",
+  kFactor: number = K_FACTOR,
+): { newRatingA: number; newRatingB: number } {
+  const expectedA = expectedScore(ratingA, ratingB);
+  const expectedB = 1 - expectedA;
+
+  const actualA = winner === "A" ? 1 : 0;
+  const actualB = winner === "B" ? 1 : 0;
+
+  return {
+    newRatingA: Math.round(ratingA + kFactor * (actualA - expectedA)),
+    newRatingB: Math.round(ratingB + kFactor * (actualB - expectedB)),
+  };
+}
+
+/**
+ * Manage Elo ratings for a set of document versions.
+ * Tracks ratings in memory; persist externally as needed.
+ */
+export class EloRanking {
+  private ratings: Map<string, EloRating> = new Map();
+
+  private key(documentId: string, revisionNumber: number): string {
+    return `${documentId}:${revisionNumber}`;
+  }
+
+  /** Get or initialize rating for a document version. */
+  getRating(documentId: string, revisionNumber: number): EloRating {
+    const k = this.key(documentId, revisionNumber);
+    let rating = this.ratings.get(k);
+    if (!rating) {
+      rating = { documentId, revisionNumber, rating: DEFAULT_ELO, matchesPlayed: 0 };
+      this.ratings.set(k, rating);
+    }
+    return { ...rating };
+  }
+
+  /** Record a comparison result and update ratings. */
+  recordResult(result: ComparisonResult): { ratingA: EloRating; ratingB: EloRating } {
+    const keyA = this.key(result.versionA.documentId, result.versionA.revisionNumber);
+    const keyB = this.key(result.versionB.documentId, result.versionB.revisionNumber);
+
+    const ratingA = this.getRating(result.versionA.documentId, result.versionA.revisionNumber);
+    const ratingB = this.getRating(result.versionB.documentId, result.versionB.revisionNumber);
+
+    const { newRatingA, newRatingB } = updateEloRatings(
+      ratingA.rating,
+      ratingB.rating,
+      result.winner,
+    );
+
+    const updatedA: EloRating = {
+      ...ratingA,
+      rating: newRatingA,
+      matchesPlayed: ratingA.matchesPlayed + 1,
+    };
+    const updatedB: EloRating = {
+      ...ratingB,
+      rating: newRatingB,
+      matchesPlayed: ratingB.matchesPlayed + 1,
+    };
+
+    this.ratings.set(keyA, updatedA);
+    this.ratings.set(keyB, updatedB);
+
+    return { ratingA: { ...updatedA }, ratingB: { ...updatedB } };
+  }
+
+  /** Get all ratings sorted by rating (highest first). */
+  getLeaderboard(): EloRating[] {
+    return [...this.ratings.values()]
+      .sort((a, b) => b.rating - a.rating);
+  }
+
+  /** Export all ratings for persistence. */
+  exportRatings(): EloRating[] {
+    return [...this.ratings.values()];
+  }
+
+  /** Import previously persisted ratings. */
+  importRatings(ratings: EloRating[]): void {
+    for (const r of ratings) {
+      this.ratings.set(this.key(r.documentId, r.revisionNumber), { ...r });
+    }
+  }
+}

--- a/packages/review-panel/src/index.ts
+++ b/packages/review-panel/src/index.ts
@@ -7,11 +7,41 @@ export type {
   ConsensusCluster,
   AggregatedReview,
   ReviewPanelOptions,
+  ScoringDimension,
+  DimensionScore,
+  DocumentScore,
+  ComparisonResult,
+  EloRating,
+  ScoreLogEntry,
+  ModelRole,
+  ModelRoleConfig,
+  ModelConfig,
 } from "./types.js";
 
 export { DEFAULT_PERSONAS, criticalEditor, domainExpert, generalReader, styleReviewer } from "./personas.js";
 export { buildPrompt, parseReviewResponse, runPersonaReview, runAllPersonas } from "./runner.js";
 export { textSimilarity, itemsRelated, clusterItems, aggregateReviews } from "./aggregator.js";
+export {
+  SCORING_DIMENSIONS,
+  buildScoringPrompt,
+  parseScoringResponse,
+  computeOverallScore,
+  scoreDocument,
+} from "./scoring.js";
+export {
+  buildComparisonPrompt,
+  parseComparisonResponse,
+  compareDocuments,
+  expectedScore,
+  updateEloRatings,
+  EloRanking,
+} from "./comparison.js";
+export {
+  DEFAULT_MODEL_CONFIG,
+  createModelConfig,
+  createCallModel,
+} from "./model-config.js";
+export { ScoreLog } from "./score-log.js";
 
 import type { AggregatedReview, ReviewPanelOptions } from "./types.js";
 import { DEFAULT_PERSONAS } from "./personas.js";

--- a/packages/review-panel/src/model-config.ts
+++ b/packages/review-panel/src/model-config.ts
@@ -1,0 +1,101 @@
+/**
+ * Writer/Judge model separation configuration.
+ *
+ * Key insight from autonovel: Using the same model for generation and evaluation
+ * creates self-congratulatory feedback loops where the model rates its own output
+ * highly. The intentional separation — different models or at least different
+ * temperature settings — produces more honest evaluation.
+ *
+ * Defaults: Sonnet (temp=0.8) for writing, Opus (temp=0.3) for judging.
+ */
+
+import type { ModelConfig, ModelRoleConfig } from "./types.js";
+
+/**
+ * Default model configuration following autonovel's proven pattern:
+ * - Writer: Sonnet at higher temperature for creative generation
+ * - Judge: Opus at lower temperature for deterministic evaluation
+ */
+export const DEFAULT_MODEL_CONFIG: ModelConfig = {
+  writer: {
+    model: "claude-sonnet-4-20250514",
+    temperature: 0.8,
+    maxTokens: 4096,
+  },
+  judge: {
+    model: "claude-opus-4-20250514",
+    temperature: 0.3,
+    maxTokens: 4096,
+  },
+};
+
+/**
+ * Create a model configuration, merging overrides with defaults.
+ */
+export function createModelConfig(
+  overrides?: Partial<{
+    writer: Partial<ModelRoleConfig>;
+    judge: Partial<ModelRoleConfig>;
+  }>,
+): ModelConfig {
+  return {
+    writer: {
+      ...DEFAULT_MODEL_CONFIG.writer,
+      ...overrides?.writer,
+    },
+    judge: {
+      ...DEFAULT_MODEL_CONFIG.judge,
+      ...overrides?.judge,
+    },
+  };
+}
+
+/**
+ * Create a callModel function for a specific role using the Anthropic Messages API.
+ *
+ * This is a convenience factory that produces the `(prompt: string) => Promise<string>`
+ * callback expected by the review panel, scoring, and comparison modules.
+ *
+ * @param roleConfig - Model configuration for this role (writer or judge)
+ * @param apiKey - Anthropic API key
+ * @param baseUrl - API base URL (defaults to Anthropic's API)
+ * @returns A callModel function bound to the role's model and temperature
+ */
+export function createCallModel(
+  roleConfig: ModelRoleConfig,
+  apiKey: string,
+  baseUrl: string = "https://api.anthropic.com",
+): (prompt: string) => Promise<string> {
+  return async (prompt: string): Promise<string> => {
+    const response = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: roleConfig.model,
+        max_tokens: roleConfig.maxTokens,
+        temperature: roleConfig.temperature,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Claude API error (${response.status}): ${error}`);
+    }
+
+    const data = (await response.json()) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const textBlock = data.content.find((b) => b.type === "text");
+    if (!textBlock) {
+      throw new Error("No text content in Claude API response");
+    }
+
+    return textBlock.text;
+  };
+}

--- a/packages/review-panel/src/score-log.ts
+++ b/packages/review-panel/src/score-log.ts
@@ -1,0 +1,101 @@
+/**
+ * Score logging for tracking improvement trajectories across revision cycles.
+ *
+ * Maintains an in-memory log of scores that can be persisted externally
+ * (e.g., to D1 or R2). Provides trajectory analysis to show whether
+ * revisions are actually improving the document.
+ */
+
+import type { DocumentScore, ScoreLogEntry } from "./types.js";
+
+/**
+ * In-memory score log that tracks scores across revision cycles.
+ * Persist externally via export/import for durability.
+ */
+export class ScoreLog {
+  private entries: ScoreLogEntry[] = [];
+
+  /** Record a document score into the log. */
+  record(score: DocumentScore): ScoreLogEntry {
+    const entry: ScoreLogEntry = {
+      documentId: score.documentId,
+      revisionNumber: score.revisionNumber,
+      overallScore: score.overallScore,
+      dimensionScores: Object.fromEntries(
+        score.dimensions.map((d) => [d.dimensionId, d.score]),
+      ),
+      model: score.model,
+      createdAt: score.createdAt,
+    };
+
+    this.entries.push(entry);
+    return entry;
+  }
+
+  /**
+   * Get the score trajectory for a document across all logged revisions.
+   * Returns entries sorted by revision number (ascending).
+   */
+  getTrajectory(documentId: string): ScoreLogEntry[] {
+    return this.entries
+      .filter((e) => e.documentId === documentId)
+      .sort((a, b) => a.revisionNumber - b.revisionNumber);
+  }
+
+  /**
+   * Compute improvement deltas between consecutive revisions.
+   * Positive delta = improvement, negative = regression.
+   */
+  getImprovementDeltas(
+    documentId: string,
+  ): Array<{
+    fromRevision: number;
+    toRevision: number;
+    overallDelta: number;
+    dimensionDeltas: Record<string, number>;
+  }> {
+    const trajectory = this.getTrajectory(documentId);
+    const deltas: Array<{
+      fromRevision: number;
+      toRevision: number;
+      overallDelta: number;
+      dimensionDeltas: Record<string, number>;
+    }> = [];
+
+    for (let i = 1; i < trajectory.length; i++) {
+      const prev = trajectory[i - 1];
+      const curr = trajectory[i];
+
+      const dimensionDeltas: Record<string, number> = {};
+      const allDimensions = new Set([
+        ...Object.keys(prev.dimensionScores),
+        ...Object.keys(curr.dimensionScores),
+      ]);
+
+      for (const dim of allDimensions) {
+        const prevScore = prev.dimensionScores[dim] ?? 0;
+        const currScore = curr.dimensionScores[dim] ?? 0;
+        dimensionDeltas[dim] = Math.round((currScore - prevScore) * 10) / 10;
+      }
+
+      deltas.push({
+        fromRevision: prev.revisionNumber,
+        toRevision: curr.revisionNumber,
+        overallDelta: Math.round((curr.overallScore - prev.overallScore) * 10) / 10,
+        dimensionDeltas,
+      });
+    }
+
+    return deltas;
+  }
+
+  /** Export all entries for persistence. */
+  exportEntries(): ScoreLogEntry[] {
+    return [...this.entries];
+  }
+
+  /** Import previously persisted entries. */
+  importEntries(entries: ScoreLogEntry[]): void {
+    this.entries.push(...entries.map((e) => ({ ...e })));
+  }
+}

--- a/packages/review-panel/src/scoring.ts
+++ b/packages/review-panel/src/scoring.ts
@@ -1,0 +1,278 @@
+/**
+ * Calibrated scoring module for document evaluation.
+ *
+ * Key insight from autonovel: Without explicit calibration, AI scores collapse
+ * to a 2-point band (typically 7-9). Calibration anchors fix this by giving
+ * the model concrete reference points for what each score means.
+ *
+ * Every score requires mandatory weakness identification with quoted evidence
+ * from the document — no score without critique.
+ */
+
+import type {
+  ScoringDimension,
+  DimensionScore,
+  DocumentScore,
+} from "./types.js";
+
+// --- Default Scoring Dimensions ---
+
+export const SCORING_DIMENSIONS: ScoringDimension[] = [
+  {
+    id: "clarity",
+    name: "Clarity",
+    description: "How clearly ideas are expressed. Can a reader understand the point on first read?",
+    anchors: {
+      2: "Most sentences require re-reading. Key terms undefined. Reader constantly lost.",
+      4: "Main argument is discernible but buried. Several confusing passages remain.",
+      6: "Median AI output. Ideas are understandable but some sections meander or use vague language.",
+      8: "Exceptional. A human editor would keep this with minor notes. Every sentence earns its place.",
+      10: "Does not exist for a first draft. Reserved for published, professionally edited prose.",
+    },
+  },
+  {
+    id: "structure",
+    name: "Structure",
+    description: "Organization, logical flow, and document architecture.",
+    anchors: {
+      2: "No discernible organization. Paragraphs could be reordered without effect.",
+      4: "Some grouping of related ideas, but transitions are missing and sections feel arbitrary.",
+      6: "Median AI output. Has sections and headers but flow is predictable rather than purposeful.",
+      8: "Exceptional. Each section builds on the last. Reader never wonders 'why is this here?'",
+      10: "Does not exist for a first draft.",
+    },
+  },
+  {
+    id: "voice",
+    name: "Voice",
+    description: "Distinctiveness, consistency of tone, and authorial presence.",
+    anchors: {
+      2: "Generic corporate/academic tone. Could have been written by any LLM with no prompting.",
+      4: "Attempts at voice but inconsistent — shifts register between paragraphs.",
+      6: "Median AI output. Competent but unremarkable. Reads like a well-prompted AI.",
+      8: "Exceptional. Distinctive voice sustained throughout. Reader can identify the author.",
+      10: "Does not exist for a first draft.",
+    },
+  },
+  {
+    id: "completeness",
+    name: "Completeness",
+    description: "Whether the document covers its topic adequately without critical gaps.",
+    anchors: {
+      2: "Major aspects of the topic are missing. Reads like an outline, not a document.",
+      4: "Covers the basics but skips important nuances or counterarguments.",
+      6: "Median AI output. Hits the expected points but adds no surprising depth.",
+      8: "Exceptional. Anticipates reader questions. Covers edge cases and counterarguments.",
+      10: "Does not exist for a first draft.",
+    },
+  },
+  {
+    id: "evidence",
+    name: "Evidence & Specificity",
+    description: "Use of concrete examples, data, and specific details rather than vague assertions.",
+    anchors: {
+      2: "All assertions, no evidence. 'This is important because it matters.'",
+      4: "Some examples but generic. Could apply to any topic in the domain.",
+      6: "Median AI output. Has examples but they feel like textbook illustrations, not lived experience.",
+      8: "Exceptional. Specific data, concrete examples, original observations that couldn't come from a template.",
+      10: "Does not exist for a first draft.",
+    },
+  },
+  {
+    id: "concision",
+    name: "Concision",
+    description: "Economy of expression. Every word earns its place.",
+    anchors: {
+      2: "Could cut 50%+ without losing meaning. Drowning in filler and redundancy.",
+      4: "Noticeably verbose. Many passages restate what was already said.",
+      6: "Median AI output. Competent length but with fat that a good editor would trim.",
+      8: "Exceptional. Lean prose. Removing any sentence would leave a gap.",
+      10: "Does not exist for a first draft.",
+    },
+  },
+];
+
+// --- Calibrated Scoring Prompt ---
+
+/**
+ * Build a calibrated scoring prompt for a document.
+ *
+ * The prompt includes:
+ * - Explicit calibration language ("median AI output = 6, an 8 is exceptional")
+ * - Anchor points for each dimension
+ * - Mandatory weakness identification with quoted evidence
+ */
+export function buildScoringPrompt(
+  document: string,
+  dimensions: ScoringDimension[] = SCORING_DIMENSIONS,
+): string {
+  const dimensionBlocks = dimensions
+    .map((dim) => {
+      const anchorLines = Object.entries(dim.anchors)
+        .sort(([a], [b]) => Number(a) - Number(b))
+        .map(([score, desc]) => `  ${score}: ${desc}`)
+        .join("\n");
+      return `### ${dim.name} (${dim.id})\n${dim.description}\n\nCalibration anchors:\n${anchorLines}`;
+    })
+    .join("\n\n");
+
+  return `You are a calibrated document evaluator. Score this document on each dimension below.
+
+CRITICAL CALIBRATION INSTRUCTIONS:
+- The median AI-generated document scores a 6. This is the baseline, not a low score.
+- An 8 means a human editor would keep it with minor notes. This is exceptional.
+- A 10 does not exist for a first draft. Never award a 10.
+- Scores of 1-3 indicate serious problems. Scores of 9 are extraordinarily rare.
+- If you cannot identify at least one weakness per dimension, your score is too high.
+- You MUST quote specific passages from the document as evidence for every weakness.
+
+SCORING DIMENSIONS:
+
+${dimensionBlocks}
+
+RESPONSE FORMAT:
+Respond with a JSON object (no markdown fences):
+{
+  "dimensions": [
+    {
+      "dimensionId": "<dimension id>",
+      "score": <number 1-10>,
+      "justification": "<why this score — reference calibration anchors>",
+      "weaknesses": [
+        {
+          "description": "<what is weak>",
+          "evidence": "<exact quoted passage from the document>"
+        }
+      ],
+      "strengths": ["<optional: what works well>"]
+    }
+  ]
+}
+
+Every dimension MUST have at least one weakness entry with a direct quote. A score without critique is invalid.
+
+---
+
+DOCUMENT TO EVALUATE:
+
+${document}`;
+}
+
+/**
+ * Parse the model's scoring response into structured DimensionScores.
+ */
+export function parseScoringResponse(
+  raw: string,
+  dimensions: ScoringDimension[] = SCORING_DIMENSIONS,
+): DimensionScore[] {
+  const cleaned = raw.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "");
+  const validIds = new Set(dimensions.map((d) => d.id));
+
+  try {
+    const parsed = JSON.parse(cleaned);
+
+    if (!Array.isArray(parsed.dimensions)) {
+      return [];
+    }
+
+    const scores: DimensionScore[] = [];
+
+    for (const dim of parsed.dimensions) {
+      if (!validIds.has(dim.dimensionId)) continue;
+
+      const score = typeof dim.score === "number"
+        ? Math.max(1, Math.min(10, Math.round(dim.score)))
+        : 6;
+
+      const weaknesses: DimensionScore["weaknesses"] = [];
+      if (Array.isArray(dim.weaknesses)) {
+        for (const w of dim.weaknesses) {
+          if (typeof w.description === "string" && typeof w.evidence === "string") {
+            weaknesses.push({
+              description: w.description.trim(),
+              evidence: w.evidence.trim(),
+            });
+          }
+        }
+      }
+
+      scores.push({
+        dimensionId: dim.dimensionId,
+        score,
+        justification: typeof dim.justification === "string"
+          ? dim.justification.trim()
+          : "",
+        weaknesses,
+        strengths: Array.isArray(dim.strengths)
+          ? dim.strengths.filter((s: unknown) => typeof s === "string")
+          : undefined,
+      });
+    }
+
+    return scores;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Compute weighted overall score from dimension scores.
+ * All dimensions are weighted equally by default.
+ */
+export function computeOverallScore(
+  dimensionScores: DimensionScore[],
+  weights?: Record<string, number>,
+): number {
+  if (dimensionScores.length === 0) return 0;
+
+  let totalWeight = 0;
+  let weightedSum = 0;
+
+  for (const ds of dimensionScores) {
+    const w = weights?.[ds.dimensionId] ?? 1;
+    weightedSum += ds.score * w;
+    totalWeight += w;
+  }
+
+  return totalWeight > 0
+    ? Math.round((weightedSum / totalWeight) * 10) / 10
+    : 0;
+}
+
+/**
+ * Run a calibrated scoring evaluation of a document.
+ *
+ * @param document - The document text to evaluate
+ * @param documentId - Identifier for the document
+ * @param revisionNumber - Which revision is being scored
+ * @param callModel - Function to call the judge model
+ * @param dimensions - Scoring dimensions (defaults to SCORING_DIMENSIONS)
+ * @returns A complete DocumentScore with all dimension scores
+ */
+export async function scoreDocument(
+  document: string,
+  documentId: string,
+  revisionNumber: number,
+  callModel: (prompt: string) => Promise<string>,
+  options?: {
+    dimensions?: ScoringDimension[];
+    weights?: Record<string, number>;
+    model?: string;
+  },
+): Promise<DocumentScore> {
+  const dimensions = options?.dimensions ?? SCORING_DIMENSIONS;
+  const prompt = buildScoringPrompt(document, dimensions);
+  const raw = await callModel(prompt);
+  const dimensionScores = parseScoringResponse(raw, dimensions);
+  const overallScore = computeOverallScore(dimensionScores, options?.weights);
+
+  return {
+    id: `score_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    documentId,
+    revisionNumber,
+    dimensions: dimensionScores,
+    overallScore,
+    model: options?.model ?? "unknown",
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/packages/review-panel/src/test/comparison.test.ts
+++ b/packages/review-panel/src/test/comparison.test.ts
@@ -1,0 +1,207 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  buildComparisonPrompt,
+  parseComparisonResponse,
+  compareDocuments,
+  expectedScore,
+  updateEloRatings,
+  EloRanking,
+} from "../comparison.js";
+
+describe("buildComparisonPrompt", () => {
+  it("includes both document versions", () => {
+    const prompt = buildComparisonPrompt("Doc A content", "Doc B content");
+    assert.ok(prompt.includes("Doc A content"));
+    assert.ok(prompt.includes("Doc B content"));
+  });
+
+  it("enforces forced choice", () => {
+    const prompt = buildComparisonPrompt("A", "B");
+    assert.ok(prompt.includes("MUST choose a winner"));
+    assert.ok(prompt.includes("no ties"));
+  });
+
+  it("includes dimension descriptions", () => {
+    const prompt = buildComparisonPrompt("A", "B");
+    assert.ok(prompt.includes("Clarity"));
+    assert.ok(prompt.includes("Structure"));
+  });
+});
+
+describe("parseComparisonResponse", () => {
+  it("parses valid response", () => {
+    const raw = JSON.stringify({
+      dimensionWins: [
+        { dimensionId: "clarity", winner: "A", reasoning: "Clearer prose" },
+        { dimensionId: "structure", winner: "B", reasoning: "Better flow" },
+      ],
+      winner: "A",
+      reasoning: "Version A has better overall clarity despite weaker structure",
+    });
+
+    const result = parseComparisonResponse(raw);
+    assert.ok(result !== null);
+    assert.equal(result!.winner, "A");
+    assert.equal(result!.dimensionWins.length, 2);
+    assert.equal(result!.dimensionWins[0].winner, "A");
+  });
+
+  it("returns null for missing winner", () => {
+    const raw = JSON.stringify({ dimensionWins: [], reasoning: "no winner" });
+    assert.equal(parseComparisonResponse(raw), null);
+  });
+
+  it("returns null for invalid winner value", () => {
+    const raw = JSON.stringify({ winner: "tie", dimensionWins: [], reasoning: "tied" });
+    assert.equal(parseComparisonResponse(raw), null);
+  });
+
+  it("returns null for non-JSON", () => {
+    assert.equal(parseComparisonResponse("not json at all"), null);
+  });
+
+  it("handles code-fenced JSON", () => {
+    const raw = '```json\n{"winner": "B", "dimensionWins": [], "reasoning": "B wins"}\n```';
+    const result = parseComparisonResponse(raw);
+    assert.ok(result !== null);
+    assert.equal(result!.winner, "B");
+  });
+});
+
+describe("compareDocuments", () => {
+  it("runs comparison end-to-end", async () => {
+    const mockResponse = JSON.stringify({
+      dimensionWins: [
+        { dimensionId: "clarity", winner: "B", reasoning: "Version B is clearer" },
+      ],
+      winner: "B",
+      reasoning: "B is better overall",
+    });
+
+    const result = await compareDocuments(
+      { documentId: "doc1", revisionNumber: 1, content: "Version A text" },
+      { documentId: "doc1", revisionNumber: 2, content: "Version B text" },
+      async () => mockResponse,
+      { model: "test-model" },
+    );
+
+    assert.equal(result.winner, "B");
+    assert.equal(result.versionA.revisionNumber, 1);
+    assert.equal(result.versionB.revisionNumber, 2);
+    assert.equal(result.model, "test-model");
+  });
+
+  it("throws on invalid model response", async () => {
+    await assert.rejects(
+      () => compareDocuments(
+        { documentId: "d", revisionNumber: 1, content: "A" },
+        { documentId: "d", revisionNumber: 2, content: "B" },
+        async () => "invalid response",
+      ),
+      { message: /Failed to parse comparison response/ },
+    );
+  });
+});
+
+describe("Elo calculations", () => {
+  it("expectedScore returns ~0.5 for equal ratings", () => {
+    const expected = expectedScore(1500, 1500);
+    assert.ok(Math.abs(expected - 0.5) < 0.001);
+  });
+
+  it("expectedScore favors higher-rated player", () => {
+    const expected = expectedScore(1600, 1400);
+    assert.ok(expected > 0.7);
+  });
+
+  it("updateEloRatings increases winner and decreases loser", () => {
+    const { newRatingA, newRatingB } = updateEloRatings(1500, 1500, "A");
+    assert.ok(newRatingA > 1500);
+    assert.ok(newRatingB < 1500);
+    // Zero-sum: changes should be equal and opposite
+    assert.equal(newRatingA - 1500, 1500 - newRatingB);
+  });
+
+  it("upset victory produces larger rating changes", () => {
+    const { newRatingA: upset } = updateEloRatings(1300, 1700, "A");
+    const { newRatingA: expected } = updateEloRatings(1700, 1300, "A");
+    // The underdog winning (1300 beats 1700) should gain more than favorite winning
+    assert.ok((upset - 1300) > (expected - 1700));
+  });
+});
+
+describe("EloRanking", () => {
+  it("initializes new documents at 1500", () => {
+    const ranking = new EloRanking();
+    const rating = ranking.getRating("doc1", 1);
+    assert.equal(rating.rating, 1500);
+    assert.equal(rating.matchesPlayed, 0);
+  });
+
+  it("updates ratings after recording a result", () => {
+    const ranking = new EloRanking();
+
+    ranking.recordResult({
+      versionA: { documentId: "doc1", revisionNumber: 1 },
+      versionB: { documentId: "doc1", revisionNumber: 2 },
+      winner: "B",
+      dimensionWins: [],
+      reasoning: "B is better",
+      model: "test",
+      createdAt: new Date().toISOString(),
+    });
+
+    const ratingA = ranking.getRating("doc1", 1);
+    const ratingB = ranking.getRating("doc1", 2);
+
+    assert.ok(ratingA.rating < 1500, "Loser should have lower rating");
+    assert.ok(ratingB.rating > 1500, "Winner should have higher rating");
+    assert.equal(ratingA.matchesPlayed, 1);
+    assert.equal(ratingB.matchesPlayed, 1);
+  });
+
+  it("maintains leaderboard sorted by rating", () => {
+    const ranking = new EloRanking();
+
+    // Record B beating A twice
+    for (let i = 0; i < 2; i++) {
+      ranking.recordResult({
+        versionA: { documentId: "doc1", revisionNumber: 1 },
+        versionB: { documentId: "doc1", revisionNumber: 2 },
+        winner: "B",
+        dimensionWins: [],
+        reasoning: "B better",
+        model: "test",
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    const leaderboard = ranking.getLeaderboard();
+    assert.equal(leaderboard.length, 2);
+    assert.equal(leaderboard[0].revisionNumber, 2); // B should be first
+    assert.ok(leaderboard[0].rating > leaderboard[1].rating);
+  });
+
+  it("supports export and import", () => {
+    const ranking1 = new EloRanking();
+    ranking1.recordResult({
+      versionA: { documentId: "doc1", revisionNumber: 1 },
+      versionB: { documentId: "doc1", revisionNumber: 2 },
+      winner: "A",
+      dimensionWins: [],
+      reasoning: "A wins",
+      model: "test",
+      createdAt: new Date().toISOString(),
+    });
+
+    const exported = ranking1.exportRatings();
+
+    const ranking2 = new EloRanking();
+    ranking2.importRatings(exported);
+
+    const rating = ranking2.getRating("doc1", 1);
+    assert.ok(rating.rating > 1500);
+    assert.equal(rating.matchesPlayed, 1);
+  });
+});

--- a/packages/review-panel/src/test/model-config.test.ts
+++ b/packages/review-panel/src/test/model-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  DEFAULT_MODEL_CONFIG,
+  createModelConfig,
+} from "../model-config.js";
+
+describe("DEFAULT_MODEL_CONFIG", () => {
+  it("uses Sonnet for writer with higher temperature", () => {
+    assert.ok(DEFAULT_MODEL_CONFIG.writer.model.includes("sonnet"));
+    assert.equal(DEFAULT_MODEL_CONFIG.writer.temperature, 0.8);
+  });
+
+  it("uses Opus for judge with lower temperature", () => {
+    assert.ok(DEFAULT_MODEL_CONFIG.judge.model.includes("opus"));
+    assert.equal(DEFAULT_MODEL_CONFIG.judge.temperature, 0.3);
+  });
+
+  it("judge model is more capable than writer model", () => {
+    // Opus is more capable than Sonnet — verified by model name
+    assert.ok(DEFAULT_MODEL_CONFIG.judge.model.includes("opus"));
+    assert.ok(DEFAULT_MODEL_CONFIG.writer.model.includes("sonnet"));
+  });
+
+  it("judge temperature is lower than writer temperature", () => {
+    assert.ok(
+      DEFAULT_MODEL_CONFIG.judge.temperature < DEFAULT_MODEL_CONFIG.writer.temperature,
+      "Judge should use lower temperature for more deterministic evaluation",
+    );
+  });
+});
+
+describe("createModelConfig", () => {
+  it("returns defaults when no overrides", () => {
+    const config = createModelConfig();
+    assert.deepEqual(config, DEFAULT_MODEL_CONFIG);
+  });
+
+  it("merges writer overrides", () => {
+    const config = createModelConfig({
+      writer: { model: "custom-writer", temperature: 0.5 },
+    });
+    assert.equal(config.writer.model, "custom-writer");
+    assert.equal(config.writer.temperature, 0.5);
+    assert.equal(config.writer.maxTokens, DEFAULT_MODEL_CONFIG.writer.maxTokens);
+    // Judge should be unchanged
+    assert.deepEqual(config.judge, DEFAULT_MODEL_CONFIG.judge);
+  });
+
+  it("merges judge overrides", () => {
+    const config = createModelConfig({
+      judge: { temperature: 0.1 },
+    });
+    assert.equal(config.judge.temperature, 0.1);
+    assert.equal(config.judge.model, DEFAULT_MODEL_CONFIG.judge.model);
+    // Writer should be unchanged
+    assert.deepEqual(config.writer, DEFAULT_MODEL_CONFIG.writer);
+  });
+
+  it("allows both overrides simultaneously", () => {
+    const config = createModelConfig({
+      writer: { model: "fast-writer" },
+      judge: { model: "careful-judge" },
+    });
+    assert.equal(config.writer.model, "fast-writer");
+    assert.equal(config.judge.model, "careful-judge");
+  });
+});

--- a/packages/review-panel/src/test/score-log.test.ts
+++ b/packages/review-panel/src/test/score-log.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { ScoreLog } from "../score-log.js";
+import type { DocumentScore } from "../types.js";
+
+function makeScore(
+  documentId: string,
+  revisionNumber: number,
+  scores: Record<string, number>,
+): DocumentScore {
+  const dimensions = Object.entries(scores).map(([id, score]) => ({
+    dimensionId: id,
+    score,
+    justification: "test",
+    weaknesses: [],
+  }));
+
+  const overallScore =
+    dimensions.reduce((sum, d) => sum + d.score, 0) / dimensions.length;
+
+  return {
+    id: `score_${revisionNumber}`,
+    documentId,
+    revisionNumber,
+    dimensions,
+    overallScore: Math.round(overallScore * 10) / 10,
+    model: "test-model",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("ScoreLog", () => {
+  it("records and retrieves scores", () => {
+    const log = new ScoreLog();
+    const score = makeScore("doc1", 1, { clarity: 6, structure: 7 });
+    log.record(score);
+
+    const trajectory = log.getTrajectory("doc1");
+    assert.equal(trajectory.length, 1);
+    assert.equal(trajectory[0].documentId, "doc1");
+    assert.equal(trajectory[0].revisionNumber, 1);
+    assert.equal(trajectory[0].overallScore, 6.5);
+    assert.equal(trajectory[0].dimensionScores["clarity"], 6);
+  });
+
+  it("returns trajectory sorted by revision number", () => {
+    const log = new ScoreLog();
+    // Record out of order
+    log.record(makeScore("doc1", 3, { clarity: 8 }));
+    log.record(makeScore("doc1", 1, { clarity: 5 }));
+    log.record(makeScore("doc1", 2, { clarity: 7 }));
+
+    const trajectory = log.getTrajectory("doc1");
+    assert.equal(trajectory.length, 3);
+    assert.equal(trajectory[0].revisionNumber, 1);
+    assert.equal(trajectory[1].revisionNumber, 2);
+    assert.equal(trajectory[2].revisionNumber, 3);
+  });
+
+  it("filters trajectory by document ID", () => {
+    const log = new ScoreLog();
+    log.record(makeScore("doc1", 1, { clarity: 6 }));
+    log.record(makeScore("doc2", 1, { clarity: 7 }));
+    log.record(makeScore("doc1", 2, { clarity: 8 }));
+
+    assert.equal(log.getTrajectory("doc1").length, 2);
+    assert.equal(log.getTrajectory("doc2").length, 1);
+    assert.equal(log.getTrajectory("doc3").length, 0);
+  });
+
+  it("computes improvement deltas", () => {
+    const log = new ScoreLog();
+    log.record(makeScore("doc1", 1, { clarity: 5, structure: 6 }));
+    log.record(makeScore("doc1", 2, { clarity: 7, structure: 6 }));
+    log.record(makeScore("doc1", 3, { clarity: 8, structure: 5 }));
+
+    const deltas = log.getImprovementDeltas("doc1");
+    assert.equal(deltas.length, 2);
+
+    // Rev 1 -> 2: clarity +2, structure 0
+    assert.equal(deltas[0].fromRevision, 1);
+    assert.equal(deltas[0].toRevision, 2);
+    assert.equal(deltas[0].dimensionDeltas["clarity"], 2);
+    assert.equal(deltas[0].dimensionDeltas["structure"], 0);
+    assert.ok(deltas[0].overallDelta > 0);
+
+    // Rev 2 -> 3: clarity +1, structure -1
+    assert.equal(deltas[1].dimensionDeltas["clarity"], 1);
+    assert.equal(deltas[1].dimensionDeltas["structure"], -1);
+  });
+
+  it("returns empty deltas for single revision", () => {
+    const log = new ScoreLog();
+    log.record(makeScore("doc1", 1, { clarity: 6 }));
+    assert.equal(log.getImprovementDeltas("doc1").length, 0);
+  });
+
+  it("supports export and import", () => {
+    const log1 = new ScoreLog();
+    log1.record(makeScore("doc1", 1, { clarity: 6 }));
+    log1.record(makeScore("doc1", 2, { clarity: 8 }));
+
+    const exported = log1.exportEntries();
+
+    const log2 = new ScoreLog();
+    log2.importEntries(exported);
+
+    assert.equal(log2.getTrajectory("doc1").length, 2);
+  });
+});

--- a/packages/review-panel/src/test/scoring.test.ts
+++ b/packages/review-panel/src/test/scoring.test.ts
@@ -1,0 +1,202 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  SCORING_DIMENSIONS,
+  buildScoringPrompt,
+  parseScoringResponse,
+  computeOverallScore,
+  scoreDocument,
+} from "../scoring.js";
+import type { DimensionScore } from "../types.js";
+
+describe("SCORING_DIMENSIONS", () => {
+  it("defines all six dimensions", () => {
+    assert.equal(SCORING_DIMENSIONS.length, 6);
+    const ids = SCORING_DIMENSIONS.map((d) => d.id);
+    assert.deepEqual(ids, ["clarity", "structure", "voice", "completeness", "evidence", "concision"]);
+  });
+
+  it("each dimension has calibration anchors", () => {
+    for (const dim of SCORING_DIMENSIONS) {
+      assert.ok(Object.keys(dim.anchors).length >= 4, `${dim.id} should have at least 4 anchors`);
+      // Anchor at 6 should mention "median AI output"
+      assert.ok(
+        dim.anchors[6]?.toLowerCase().includes("median"),
+        `${dim.id} anchor at 6 should mention median`,
+      );
+      // Anchor at 10 should mention "does not exist"
+      assert.ok(
+        dim.anchors[10]?.toLowerCase().includes("does not exist"),
+        `${dim.id} anchor at 10 should mention impossibility`,
+      );
+    }
+  });
+});
+
+describe("buildScoringPrompt", () => {
+  it("includes calibration language", () => {
+    const prompt = buildScoringPrompt("Test document");
+    assert.ok(prompt.includes("median AI-generated document scores a 6"), "Should include calibration baseline");
+    assert.ok(prompt.includes("8 means a human editor would keep it"), "Should include 8-level anchor");
+    assert.ok(prompt.includes("10 does not exist for a first draft"), "Should include 10-level anchor");
+  });
+
+  it("includes mandatory weakness requirement", () => {
+    const prompt = buildScoringPrompt("Test document");
+    assert.ok(prompt.includes("weakness"), "Should require weakness identification");
+    assert.ok(prompt.includes("evidence"), "Should require quoted evidence");
+    assert.ok(prompt.includes("score without critique is invalid"), "Should state no score without critique");
+  });
+
+  it("includes the document text", () => {
+    const prompt = buildScoringPrompt("My special document content");
+    assert.ok(prompt.includes("My special document content"));
+  });
+
+  it("includes all dimension anchors", () => {
+    const prompt = buildScoringPrompt("Test");
+    for (const dim of SCORING_DIMENSIONS) {
+      assert.ok(prompt.includes(dim.name), `Should include ${dim.name} dimension`);
+    }
+  });
+});
+
+describe("parseScoringResponse", () => {
+  it("parses valid JSON response", () => {
+    const raw = JSON.stringify({
+      dimensions: [
+        {
+          dimensionId: "clarity",
+          score: 7,
+          justification: "Clear but some passages meander",
+          weaknesses: [
+            {
+              description: "Paragraph 3 restates the opening",
+              evidence: "As mentioned earlier, the key insight is...",
+            },
+          ],
+          strengths: ["Strong opening sentence"],
+        },
+      ],
+    });
+
+    const scores = parseScoringResponse(raw);
+    assert.equal(scores.length, 1);
+    assert.equal(scores[0].dimensionId, "clarity");
+    assert.equal(scores[0].score, 7);
+    assert.equal(scores[0].weaknesses.length, 1);
+    assert.equal(scores[0].weaknesses[0].evidence, "As mentioned earlier, the key insight is...");
+    assert.deepEqual(scores[0].strengths, ["Strong opening sentence"]);
+  });
+
+  it("clamps scores to 1-10 range", () => {
+    const raw = JSON.stringify({
+      dimensions: [
+        { dimensionId: "clarity", score: 15, justification: "test", weaknesses: [] },
+        { dimensionId: "structure", score: -3, justification: "test", weaknesses: [] },
+      ],
+    });
+
+    const scores = parseScoringResponse(raw);
+    assert.equal(scores[0].score, 10);
+    assert.equal(scores[1].score, 1);
+  });
+
+  it("rejects unknown dimension IDs", () => {
+    const raw = JSON.stringify({
+      dimensions: [
+        { dimensionId: "nonexistent", score: 5, justification: "test", weaknesses: [] },
+        { dimensionId: "clarity", score: 6, justification: "test", weaknesses: [] },
+      ],
+    });
+
+    const scores = parseScoringResponse(raw);
+    assert.equal(scores.length, 1);
+    assert.equal(scores[0].dimensionId, "clarity");
+  });
+
+  it("handles JSON wrapped in code fences", () => {
+    const raw = '```json\n{"dimensions": [{"dimensionId": "clarity", "score": 5, "justification": "ok", "weaknesses": []}]}\n```';
+    const scores = parseScoringResponse(raw);
+    assert.equal(scores.length, 1);
+  });
+
+  it("returns empty array for non-JSON", () => {
+    const scores = parseScoringResponse("This is not JSON");
+    assert.equal(scores.length, 0);
+  });
+
+  it("defaults score to 6 if not a number", () => {
+    const raw = JSON.stringify({
+      dimensions: [
+        { dimensionId: "clarity", score: "high", justification: "test", weaknesses: [] },
+      ],
+    });
+    const scores = parseScoringResponse(raw);
+    assert.equal(scores[0].score, 6);
+  });
+});
+
+describe("computeOverallScore", () => {
+  it("computes equal-weighted average", () => {
+    const scores: DimensionScore[] = [
+      { dimensionId: "clarity", score: 6, justification: "", weaknesses: [] },
+      { dimensionId: "structure", score: 8, justification: "", weaknesses: [] },
+    ];
+    const overall = computeOverallScore(scores);
+    assert.equal(overall, 7);
+  });
+
+  it("supports custom weights", () => {
+    const scores: DimensionScore[] = [
+      { dimensionId: "clarity", score: 10, justification: "", weaknesses: [] },
+      { dimensionId: "structure", score: 0, justification: "", weaknesses: [] },
+    ];
+    // clarity weight 3, structure weight 1 => (10*3 + 0*1) / 4 = 7.5
+    const overall = computeOverallScore(scores, { clarity: 3, structure: 1 });
+    assert.equal(overall, 7.5);
+  });
+
+  it("returns 0 for empty scores", () => {
+    assert.equal(computeOverallScore([]), 0);
+  });
+});
+
+describe("scoreDocument", () => {
+  it("runs scoring pipeline end-to-end", async () => {
+    const mockResponse = JSON.stringify({
+      dimensions: [
+        {
+          dimensionId: "clarity",
+          score: 7,
+          justification: "Good clarity",
+          weaknesses: [{ description: "Some vagueness", evidence: "the thing is important" }],
+        },
+        {
+          dimensionId: "structure",
+          score: 6,
+          justification: "Decent structure",
+          weaknesses: [{ description: "Flat hierarchy", evidence: "section 1, section 2, section 3" }],
+        },
+      ],
+    });
+
+    const callModel = async (_prompt: string) => mockResponse;
+
+    const result = await scoreDocument(
+      "Test document content",
+      "doc-123",
+      1,
+      callModel,
+      { model: "test-model" },
+    );
+
+    assert.equal(result.documentId, "doc-123");
+    assert.equal(result.revisionNumber, 1);
+    assert.equal(result.dimensions.length, 2);
+    assert.equal(result.overallScore, 6.5);
+    assert.equal(result.model, "test-model");
+    assert.ok(result.id.startsWith("score_"));
+    assert.ok(result.createdAt);
+  });
+});

--- a/packages/review-panel/src/types.ts
+++ b/packages/review-panel/src/types.ts
@@ -119,3 +119,139 @@ export interface ReviewPanelOptions {
   /** Function to call the AI model. Allows different backends (Claude API, local, etc.) */
   callModel: (prompt: string) => Promise<string>;
 }
+
+// --- Calibrated Scoring Types ---
+
+/**
+ * A scoring dimension with calibration anchors that prevent score inflation.
+ * Each anchor gives the model a concrete reference point for what a given score means.
+ */
+export interface ScoringDimension {
+  /** Unique identifier (e.g., "clarity", "structure") */
+  id: string;
+  /** Display name */
+  name: string;
+  /** What this dimension measures */
+  description: string;
+  /** Calibration anchors mapping score values to concrete descriptions */
+  anchors: Record<number, string>;
+}
+
+/**
+ * A score for a single dimension, with mandatory weakness identification.
+ * No score without critique — the model must quote evidence from the document.
+ */
+export interface DimensionScore {
+  /** Which dimension was scored */
+  dimensionId: string;
+  /** Numeric score (1-10) */
+  score: number;
+  /** Brief justification for the score */
+  justification: string;
+  /** Identified weaknesses with quoted evidence from the document */
+  weaknesses: Array<{
+    /** Description of the weakness */
+    description: string;
+    /** Exact quote from the document demonstrating the weakness */
+    evidence: string;
+  }>;
+  /** Identified strengths (optional but encouraged) */
+  strengths?: string[];
+}
+
+/**
+ * Complete scored evaluation of a document across all dimensions.
+ */
+export interface DocumentScore {
+  /** Unique ID for this scoring session */
+  id: string;
+  /** Document identifier */
+  documentId: string;
+  /** Revision number that was scored */
+  revisionNumber: number;
+  /** Individual dimension scores */
+  dimensions: DimensionScore[];
+  /** Weighted overall score */
+  overallScore: number;
+  /** Model used for this evaluation */
+  model: string;
+  /** Timestamp */
+  createdAt: string;
+}
+
+/**
+ * Result of a head-to-head comparison between two document versions.
+ * Forced choice produces more reliable rankings than absolute scoring.
+ */
+export interface ComparisonResult {
+  /** ID of version A */
+  versionA: { documentId: string; revisionNumber: number };
+  /** ID of version B */
+  versionB: { documentId: string; revisionNumber: number };
+  /** Which version won ("A" | "B") — forced choice, no ties */
+  winner: "A" | "B";
+  /** Dimension-by-dimension comparison */
+  dimensionWins: Array<{
+    dimensionId: string;
+    winner: "A" | "B";
+    reasoning: string;
+  }>;
+  /** Overall reasoning for the choice */
+  reasoning: string;
+  /** Model used for comparison */
+  model: string;
+  /** Timestamp */
+  createdAt: string;
+}
+
+/**
+ * Elo rating for a document version, updated after each comparison.
+ */
+export interface EloRating {
+  documentId: string;
+  revisionNumber: number;
+  rating: number;
+  matchesPlayed: number;
+}
+
+/**
+ * A log entry tracking scores across revision cycles.
+ */
+export interface ScoreLogEntry {
+  documentId: string;
+  revisionNumber: number;
+  overallScore: number;
+  dimensionScores: Record<string, number>;
+  model: string;
+  createdAt: string;
+}
+
+// --- Model Configuration Types ---
+
+/** Role-based model configuration for writer/judge separation. */
+export type ModelRole = "writer" | "judge";
+
+/**
+ * Configuration for a specific model role.
+ * Different roles should use different models/temperatures to prevent
+ * self-congratulatory feedback loops.
+ */
+export interface ModelRoleConfig {
+  /** Model identifier (e.g., "claude-sonnet-4-20250514", "claude-opus-4-20250514") */
+  model: string;
+  /** Temperature setting (lower = more deterministic judgment) */
+  temperature: number;
+  /** Maximum tokens for response */
+  maxTokens: number;
+}
+
+/**
+ * Complete model configuration with writer/judge separation.
+ * The judge should default to a more capable model than the writer.
+ */
+export interface ModelConfig {
+  /** Model config for content generation / revision */
+  writer: ModelRoleConfig;
+  /** Model config for evaluation / scoring / comparison */
+  judge: ModelRoleConfig;
+}


### PR DESCRIPTION
## Summary
Adds calibrated document scoring, head-to-head Elo comparison, writer/judge model separation, and score trajectory tracking to the review-panel package. Implements autonovel's key insights: explicit calibration prevents AI score inflation, forced-choice comparison beats absolute scoring, and using different models for generation vs evaluation prevents self-congratulatory feedback loops.

## Changes
- **scoring.ts**: 6 scoring dimensions (clarity, structure, voice, completeness, evidence, concision) with calibrated anchor points ("median AI output = 6, an 8 is exceptional, 10 does not exist for a first draft") and mandatory weakness identification with quoted evidence
- **comparison.ts**: Head-to-head forced-choice document comparison with full Elo rating system (EloRanking class with leaderboard, export/import)
- **model-config.ts**: Writer/judge separation defaults — Sonnet (temp=0.8) for writing, Opus (temp=0.3) for judging — with configurable overrides via `createModelConfig()`
- **score-log.ts**: Score trajectory tracking across revision cycles with improvement delta computation
- **types.ts**: New types for ScoringDimension, DimensionScore, DocumentScore, ComparisonResult, EloRating, ScoreLogEntry, ModelConfig
- **index.ts**: Exports all new modules
- **migrations/0002_score_tracking.sql**: D1 schema for persisting scores, dimension scores with weaknesses, Elo ratings, and comparisons

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Define scoring dimensions for document review | ✅ | 6 dimensions defined in SCORING_DIMENSIONS: clarity, structure, voice, completeness, evidence, concision |
| Include explicit calibration language with anchor points | ✅ | Every dimension has anchors at 2/4/6/8/10; prompt includes "median AI output = 6", "8 means human editor would keep it", "10 does not exist for a first draft" |
| Require weakness identification with quoted evidence | ✅ | Prompt mandates "at least one weakness per dimension with a direct quote", declares "score without critique is invalid" |
| Configure separate model/temperature for review vs revision | ✅ | ModelConfig type with writer/judge roles; createModelConfig() merges overrides; createCallModel() factory |
| Default: more capable model for judgment | ✅ | DEFAULT_MODEL_CONFIG uses Opus for judge, Sonnet for writer |
| Support head-to-head comparison (Elo ranking) | ✅ | compareDocuments() for pairwise forced-choice; EloRanking class with recordResult(), getLeaderboard(), export/import |
| Log scores over revision cycles | ✅ | ScoreLog class with record(), getTrajectory(), getImprovementDeltas(), export/import |

## Test Plan
- 68 tests pass across 22 suites (all existing + 4 new test files)
- `pnpm build` compiles cleanly
- `pnpm check` (tsc --noEmit) passes
- New tests cover: scoring dimensions, calibration prompts, response parsing, score clamping, overall score computation, comparison prompts, forced-choice parsing, Elo math, EloRanking class, ScoreLog trajectory/deltas, model config defaults/overrides

Closes #7