### PR TITLE
feat: wire real API data into Dashboard, Profile, and Settings pages

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -300,6 +300,73 @@ async function handleGetMe(env: Env, request: Request): Promise<Response> {
   return json({ user });
 }
 
+async function handleUpdateMe(env: Env, request: Request): Promise<Response> {
+  const user = await getAuthenticatedUser(env, request);
+  if (!user) return error("Not authenticated", 401);
+
+  const body = (await request.json()) as { name?: string };
+  const { name } = body;
+
+  if (!name || !name.trim()) {
+    return error("Name is required");
+  }
+
+  await env.DB.prepare("UPDATE users SET name = ?, updated_at = datetime('now') WHERE id = ?")
+    .bind(name.trim(), user.id)
+    .run();
+
+  return json({ user: { id: user.id, email: user.email, name: name.trim() } });
+}
+
+async function handleDeleteMe(env: Env, request: Request): Promise<Response> {
+  const user = await getAuthenticatedUser(env, request);
+  if (!user) return error("Not authenticated", 401);
+
+  // Delete user — cascades to sessions, projects, documents, reviews, revisions
+  // via ON DELETE CASCADE foreign keys.
+  // Also clean up R2 objects for the user's documents and reviews.
+  const { results: projects } = await env.DB.prepare(
+    "SELECT id FROM projects WHERE user_id = ?",
+  )
+    .bind(user.id)
+    .all<{ id: string }>();
+
+  for (const project of projects) {
+    const { results: documents } = await env.DB.prepare(
+      "SELECT r2_key FROM documents WHERE project_id = ?",
+    )
+      .bind(project.id)
+      .all<{ r2_key: string }>();
+
+    const { results: reviews } = await env.DB.prepare(
+      "SELECT r.r2_key FROM reviews r JOIN documents d ON r.document_id = d.id WHERE d.project_id = ?",
+    )
+      .bind(project.id)
+      .all<{ r2_key: string }>();
+
+    const { results: revisions } = await env.DB.prepare(
+      "SELECT rv.r2_key FROM revisions rv JOIN documents d ON rv.document_id = d.id WHERE d.project_id = ?",
+    )
+      .bind(project.id)
+      .all<{ r2_key: string }>();
+
+    const r2Keys = [
+      ...documents.map((d) => d.r2_key),
+      ...reviews.map((r) => r.r2_key),
+      ...revisions.map((r) => r.r2_key),
+    ];
+
+    for (const key of r2Keys) {
+      await env.CONTENT_BUCKET.delete(key);
+    }
+  }
+
+  // Delete user row — cascades delete sessions, projects, documents, reviews, etc.
+  await env.DB.prepare("DELETE FROM users WHERE id = ?").bind(user.id).run();
+
+  return json({ success: true }, 200, { "Set-Cookie": clearSessionCookie() });
+}
+
 async function handleRefreshSession(env: Env, request: Request): Promise<Response> {
   const sessionId = getSessionIdFromCookie(request);
 
@@ -1448,6 +1515,14 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
     if (path === "/api/auth/me" && method === "GET") {
       return handleGetMe(env, request);
+    }
+
+    if (path === "/api/auth/me" && method === "PUT") {
+      return handleUpdateMe(env, request);
+    }
+
+    if (path === "/api/auth/me" && method === "DELETE") {
+      return handleDeleteMe(env, request);
     }
 
     if (path === "/api/auth/refresh" && method === "POST") {

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -12,6 +12,8 @@ interface AuthContextValue {
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   register: (email: string, password: string, name: string) => Promise<void>;
+  updateProfile: (name: string) => Promise<void>;
+  deleteAccount: () => Promise<void>;
 }
 
 interface ApiError {
@@ -90,6 +92,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const updateProfile = useCallback(async (name: string) => {
+    const response = await fetchWithCredentials("/api/auth/me", {
+      method: "PUT",
+      body: JSON.stringify({ name }),
+    });
+
+    if (!response.ok) {
+      const data: ApiError = await response.json();
+      throw new Error(data.error || "Failed to update profile");
+    }
+
+    const data = await response.json();
+    setUser(data.user);
+  }, []);
+
+  const deleteAccount = useCallback(async () => {
+    const response = await fetchWithCredentials("/api/auth/me", {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const data: ApiError = await response.json();
+      throw new Error(data.error || "Failed to delete account");
+    }
+
+    setUser(null);
+  }, []);
+
   const register = useCallback(async (email: string, password: string, name: string) => {
     setIsLoading(true);
     try {
@@ -111,7 +141,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, logout, register }}>
+    <AuthContext.Provider value={{ user, isLoading, login, logout, register, updateProfile, deleteAccount }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,8 +1,105 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/use-auth";
 
+interface Project {
+  id: string;
+  name: string;
+  description: string | null;
+  status: "active" | "archived";
+  created_at: string;
+  updated_at: string;
+}
+
+interface Document {
+  id: string;
+  project_id: string;
+  title: string;
+  current_revision: number;
+  created_at: string;
+  updated_at: string;
+}
+
 export function DashboardPage() {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [documentCount, setDocumentCount] = useState(0);
+  const [recentActivity, setRecentActivity] = useState<{ action: string; time: string }[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchDashboardData = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      const projectsRes = await fetch("/api/projects", { credentials: "include" });
+      if (!projectsRes.ok) return;
+      const projectsData = await projectsRes.json();
+      const allProjects: Project[] = projectsData.projects || [];
+      setProjects(allProjects);
+
+      // Fetch documents for each project to get total count and recent activity
+      let totalDocs = 0;
+      const allDocs: (Document & { projectName: string })[] = [];
+
+      for (const project of allProjects) {
+        const docsRes = await fetch(`/api/projects/${project.id}/documents`, {
+          credentials: "include",
+        });
+        if (docsRes.ok) {
+          const docsData = await docsRes.json();
+          const docs: Document[] = docsData.documents || [];
+          totalDocs += docs.length;
+          for (const doc of docs) {
+            allDocs.push({ ...doc, projectName: project.name });
+          }
+        }
+      }
+      setDocumentCount(totalDocs);
+
+      // Build recent activity from projects and documents, sorted by most recent
+      const activities: { action: string; time: string; date: Date }[] = [];
+
+      for (const project of allProjects) {
+        activities.push({
+          action: `Created project "${project.name}"`,
+          time: formatRelativeTime(new Date(project.created_at)),
+          date: new Date(project.created_at),
+        });
+      }
+
+      for (const doc of allDocs) {
+        activities.push({
+          action: `Added "${doc.title}" to ${doc.projectName}`,
+          time: formatRelativeTime(new Date(doc.created_at)),
+          date: new Date(doc.created_at),
+        });
+      }
+
+      activities.sort((a, b) => b.date.getTime() - a.date.getTime());
+      setRecentActivity(activities.slice(0, 5).map(({ action, time }) => ({ action, time })));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchDashboardData();
+  }, [fetchDashboardData]);
+
+  const activeProjects = projects.filter((p) => p.status === "active").length;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-8">
@@ -11,96 +108,36 @@ export function DashboardPage() {
         <p className="text-muted-foreground">Welcome back, {user?.name}!</p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Projects</CardTitle>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              className="h-4 w-4 text-muted-foreground"
-            >
-              <title>Total Projects</title>
-              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-              <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-            </svg>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">3</div>
-            <p className="text-xs text-muted-foreground">+2 from last month</p>
+            <div className="text-2xl font-bold">{projects.length}</div>
+            <p className="text-xs text-muted-foreground">
+              {activeProjects} active
+            </p>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Tasks</CardTitle>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              className="h-4 w-4 text-muted-foreground"
-            >
-              <title>Active Tasks</title>
-              <rect width="20" height="14" x="2" y="5" rx="2" />
-              <path d="M2 10h20" />
-            </svg>
+            <CardTitle className="text-sm font-medium">Total Documents</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">12</div>
-            <p className="text-xs text-muted-foreground">4 due this week</p>
+            <div className="text-2xl font-bold">{documentCount}</div>
+            <p className="text-xs text-muted-foreground">
+              Across all projects
+            </p>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Completed</CardTitle>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              className="h-4 w-4 text-muted-foreground"
-            >
-              <title>Completed</title>
-              <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-            </svg>
+            <CardTitle className="text-sm font-medium">Account</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">24</div>
-            <p className="text-xs text-muted-foreground">+8 this month</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Uptime</CardTitle>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              className="h-4 w-4 text-muted-foreground"
-            >
-              <title>Uptime</title>
-              <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-            </svg>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">99.9%</div>
-            <p className="text-xs text-muted-foreground">Last 30 days</p>
+            <div className="text-2xl font-bold truncate">{user?.email}</div>
+            <p className="text-xs text-muted-foreground">{user?.name}</p>
           </CardContent>
         </Card>
       </div>
@@ -112,22 +149,23 @@ export function DashboardPage() {
             <CardDescription>Your recent project activity</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {[
-                { action: "Created new project", time: "2 hours ago" },
-                { action: "Deployed to production", time: "4 hours ago" },
-                { action: "Updated database schema", time: "Yesterday" },
-                { action: "Added new team member", time: "2 days ago" },
-              ].map((item) => (
-                <div key={item.action} className="flex items-center">
-                  <div className="h-2 w-2 rounded-full bg-primary mr-3" />
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">{item.action}</p>
-                    <p className="text-xs text-muted-foreground">{item.time}</p>
+            {recentActivity.length > 0 ? (
+              <div className="space-y-4">
+                {recentActivity.map((item) => (
+                  <div key={`${item.action}-${item.time}`} className="flex items-center">
+                    <div className="h-2 w-2 rounded-full bg-primary mr-3" />
+                    <div className="flex-1">
+                      <p className="text-sm font-medium">{item.action}</p>
+                      <p className="text-xs text-muted-foreground">{item.time}</p>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No activity yet. Create a project to get started.
+              </p>
+            )}
           </CardContent>
         </Card>
         <Card className="col-span-3">
@@ -139,30 +177,48 @@ export function DashboardPage() {
             <button
               type="button"
               className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+              onClick={() => navigate("/projects")}
             >
-              Create new project
+              View projects
             </button>
             <button
               type="button"
               className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+              onClick={() => navigate("/voice")}
             >
-              Deploy changes
+              Voice profile
             </button>
             <button
               type="button"
               className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+              onClick={() => navigate("/profile")}
             >
-              View analytics
+              Edit profile
             </button>
             <button
               type="button"
               className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+              onClick={() => navigate("/settings")}
             >
-              Manage team
+              Settings
             </button>
           </CardContent>
         </Card>
       </div>
     </div>
   );
+}
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes === 1 ? "" : "s"} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
+  return date.toLocaleDateString();
 }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useVoiceProfile } from "@/hooks/use-voice-profile";
 
 export function ProfilePage() {
-  const { user } = useAuth();
+  const { user, updateProfile } = useAuth();
   const navigate = useNavigate();
   const { profiles, isLoading: profilesLoading } = useVoiceProfile();
   const [isEditing, setIsEditing] = useState(false);
@@ -22,14 +22,14 @@ export function ProfilePage() {
     setMessage(null);
 
     try {
-      // In a real app, this would call PUT /api/profile
-      // For demo, we just simulate success
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
+      await updateProfile(name.trim());
       setMessage({ type: "success", text: "Profile updated successfully" });
       setIsEditing(false);
-    } catch {
-      setMessage({ type: "error", text: "Failed to update profile" });
+    } catch (err) {
+      setMessage({
+        type: "error",
+        text: err instanceof Error ? err.message : "Failed to update profile",
+      });
     } finally {
       setIsSaving(false);
     }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,16 +7,13 @@ import { useAuth } from "@/hooks/use-auth";
 import { useTheme } from "@/hooks/use-theme";
 
 export function SettingsPage() {
-  const { logout } = useAuth();
+  const { deleteAccount } = useAuth();
   const { theme, setTheme } = useTheme();
   const navigate = useNavigate();
   const [notifications, setNotifications] = useState(true);
 
   const handleDeleteAccount = async () => {
-    // In a real app, this would call DELETE /api/profile
-    // For demo, we just logout and navigate
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    await logout();
+    await deleteAccount();
     navigate("/");
   };
 


### PR DESCRIPTION
## Summary
Replace hardcoded/simulated data in Dashboard, Profile, and Settings pages with real API calls. Adds two new API endpoints (`PUT /api/auth/me`, `DELETE /api/auth/me`) and wires all three pages to live data.

## Changes
- **API**: Add `PUT /api/auth/me` endpoint to update user name
- **API**: Add `DELETE /api/auth/me` endpoint with full cascade (R2 objects + DB rows via ON DELETE CASCADE)
- **Auth hook**: Expose `updateProfile()` and `deleteAccount()` methods on `useAuth`
- **DashboardPage**: Fetch projects and documents from API, compute metrics client-side (project count, document count, recent activity), show empty states
- **ProfilePage**: Wire name edit form to `PUT /api/auth/me` instead of `setTimeout` simulation
- **SettingsPage**: Wire account deletion to `DELETE /api/auth/me` instead of `setTimeout` simulation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Dashboard shows real project/document counts | ✅ | Fetches GET /api/projects and GET /api/projects/:id/documents, computes counts |
| Dashboard shows real recent activity | ✅ | Builds activity list from project/document creation timestamps |
| Dashboard shows empty state when no data | ✅ | Conditional rendering for zero activity |
| Profile name edit calls real API | ✅ | Calls PUT /api/auth/me, updates auth context user state |
| Account deletion calls real API | ✅ | Calls DELETE /api/auth/me, clears R2 objects and DB rows |
| No hardcoded data remains | ✅ | Removed all static numbers and setTimeout simulations |
| No breaking changes | ✅ | Existing GET /api/auth/me unchanged, new endpoints only |

## Test Plan
- All 194 existing tests pass
- TypeScript compiles without new errors (pre-existing pdf-export.ts errors only)
- Manual verification: Dashboard renders loading then real data, Profile saves name via API, Settings deletes account via API with cascade

Closes #53