### PR TITLE
feat: wire styleguide checker, multi-persona review, and scoring into API

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -1,17 +1,15 @@
 // Cloudflare Pages Functions API handler
 // This provides a simple API layer for the frontend
 
+import { reviewDocument, scoreDocument } from "../../packages/review-panel/src/index";
+import type { VoiceProfileRules } from "../../packages/review-panel/src/types";
+import { check, defaultStyleguide } from "../../packages/styleguide/src/index";
 import {
   buildRefinementPrompt,
-  buildReviewPrompt,
   buildRevisionPrompt,
   callClaudeAPI,
-  chunkSections,
   estimateTokens,
-  parseReviewResponse,
   parseRevisionResponse,
-  parseSections,
-  type ReviewItemResult,
 } from "../lib/pipeline";
 
 interface Env {
@@ -747,6 +745,62 @@ function getGatewayUrl(env: Env): string | undefined {
   return undefined;
 }
 
+/** Map review-panel severity to API severity */
+function mapPersonaSeverity(
+  severity: "critical" | "major" | "minor" | "suggestion",
+): "error" | "warning" | "suggestion" {
+  switch (severity) {
+    case "critical":
+      return "error";
+    case "major":
+      return "warning";
+    case "minor":
+      return "warning";
+    case "suggestion":
+      return "suggestion";
+  }
+}
+
+/** Map styleguide severity to API severity */
+function mapStyleguideSeverity(
+  severity: "error" | "warning" | "info" | "suggestion",
+): "error" | "warning" | "suggestion" {
+  switch (severity) {
+    case "error":
+      return "error";
+    case "warning":
+      return "warning";
+    case "info":
+      return "suggestion";
+    case "suggestion":
+      return "suggestion";
+  }
+}
+
+/** Fetch voice profile rules for the user's active profile, if any */
+async function getUserVoiceProfile(
+  env: Env,
+  userId: string,
+): Promise<VoiceProfileRules | undefined> {
+  const profile = await env.DB.prepare(
+    "SELECT profile_data FROM voice_profiles WHERE user_id = ? ORDER BY updated_at DESC LIMIT 1",
+  )
+    .bind(userId)
+    .first<{ profile_data: string }>();
+
+  if (!profile?.profile_data) return undefined;
+
+  try {
+    const data = JSON.parse(profile.profile_data);
+    if (data.dimensions && data.summary && data.escape_clause) {
+      return data as VoiceProfileRules;
+    }
+  } catch {
+    // Invalid profile data, skip
+  }
+  return undefined;
+}
+
 async function handleGenerateReview(
   env: Env,
   request: Request,
@@ -775,38 +829,36 @@ async function handleGenerateReview(
   const content = object ? await object.text() : "";
   if (!content.trim()) return error("Document is empty", 400);
 
-  // Parse and chunk the document
-  const sections = parseSections(content);
-  const chunks = chunkSections(sections);
+  // Phase 1: Run styleguide check (pure regex, no AI calls, instant)
+  const styleguideReport = check(content, defaultStyleguide);
 
-  // Generate review for each chunk
-  const allItems: ReviewItemResult[] = [];
-  const summaries: string[] = [];
+  // Phase 2: Run multi-persona AI review in parallel
+  const voiceProfile = await getUserVoiceProfile(env, userId);
+  const aggregatedReview = await reviewDocument(content, {
+    callModel: (prompt: string) =>
+      callClaudeAPI(prompt, apiKey, {
+        maxTokens: 4096,
+        gatewayUrl: getGatewayUrl(env),
+        gatewayToken: env.AI_GATEWAY_TOKEN,
+      }),
+    voiceProfile,
+  });
 
-  for (let i = 0; i < chunks.length; i++) {
-    const prompt = buildReviewPrompt(chunks[i].text, i, chunks.length);
-    const response = await callClaudeAPI(prompt, apiKey, {
-      maxTokens: 4096,
-      gatewayUrl: getGatewayUrl(env),
-      gatewayToken: env.AI_GATEWAY_TOKEN,
-    });
-    const result = parseReviewResponse(response);
-    allItems.push(...result.items);
-    summaries.push(result.summary);
-  }
-
-  const combinedSummary = summaries.join(" ");
+  // Build summary from persona reviews
+  const personaSummaries = aggregatedReview.personaReviews.map((pr) => pr.summary).filter(Boolean);
+  const combinedSummary =
+    personaSummaries.length > 0 ? personaSummaries.join(" ") : "Review complete.";
 
   // Create review record
   const reviewId = crypto.randomUUID();
   const now = new Date().toISOString();
   const r2Key = `users/${userId}/projects/${projectId}/documents/${docId}/reviews/${reviewId}.json`;
 
-  // Store full review data in R2
+  // Store full review data in R2 (includes styleguide report and persona details)
   const reviewData = {
     summary: combinedSummary,
-    items: allItems,
-    chunks: chunks.length,
+    styleguide: styleguideReport,
+    aggregatedReview,
     estimatedTokens: estimateTokens(content),
     generatedAt: now,
   };
@@ -819,23 +871,70 @@ async function handleGenerateReview(
     .bind(reviewId, docId, doc.current_revision, r2Key, now)
     .run();
 
-  // Create review_items records in D1
+  // Convert multi-persona consensus items to review_items records
   const itemRecords = [];
-  for (const item of allItems) {
+
+  // Add consensus cluster items (highest value — multiple personas agree)
+  for (const cluster of aggregatedReview.clusters) {
     const itemId = crypto.randomUUID();
+    const severity = mapPersonaSeverity(cluster.severity);
+    const description = `[${cluster.consensusCount}/${cluster.totalPersonas} personas] ${cluster.representativeDescription}`;
     await env.DB.prepare(
       "INSERT INTO review_items (id, review_id, category, description, severity, location, status) VALUES (?, ?, ?, ?, ?, ?, 'open')",
     )
-      .bind(itemId, reviewId, item.category, item.description, item.severity, item.location)
+      .bind(itemId, reviewId, cluster.category, description, severity, null)
       .run();
     itemRecords.push({
       id: itemId,
       review_id: reviewId,
-      category: item.category,
-      description: item.description,
-      severity: item.severity,
-      location: item.location,
-      suggestion: item.suggestion,
+      category: cluster.category,
+      description,
+      severity,
+      location: null,
+      suggestion: cluster.items[0]?.suggestion ?? null,
+      status: "open",
+    });
+  }
+
+  // Add styleguide violations as review items (category: "styleguide")
+  for (const result of styleguideReport.results) {
+    const itemId = crypto.randomUUID();
+    const severity = mapStyleguideSeverity(result.severity);
+    const location = `line ${result.line}`;
+    await env.DB.prepare(
+      "INSERT INTO review_items (id, review_id, category, description, severity, location, status) VALUES (?, ?, ?, ?, ?, ?, 'open')",
+    )
+      .bind(itemId, reviewId, "styleguide", result.description, severity, location)
+      .run();
+    itemRecords.push({
+      id: itemId,
+      review_id: reviewId,
+      category: "styleguide",
+      description: result.description,
+      severity,
+      location,
+      suggestion: result.suggestion ?? null,
+      status: "open",
+    });
+  }
+
+  // Add structural violations from styleguide
+  for (const result of styleguideReport.structuralResults) {
+    const itemId = crypto.randomUUID();
+    const severity = mapStyleguideSeverity(result.severity);
+    await env.DB.prepare(
+      "INSERT INTO review_items (id, review_id, category, description, severity, location, status) VALUES (?, ?, ?, ?, ?, ?, 'open')",
+    )
+      .bind(itemId, reviewId, "styleguide", result.description, severity, null)
+      .run();
+    itemRecords.push({
+      id: itemId,
+      review_id: reviewId,
+      category: "styleguide",
+      description: result.description,
+      severity,
+      location: null,
+      suggestion: result.suggestion ?? null,
       status: "open",
     });
   }
@@ -850,6 +949,11 @@ async function handleGenerateReview(
         created_at: now,
       },
       items: itemRecords,
+      styleguide: {
+        score: styleguideReport.score,
+        totalIssues: styleguideReport.totalIssues,
+        counts: styleguideReport.counts,
+      },
     },
     201,
   );
@@ -1418,6 +1522,147 @@ async function handleGenerateRefinement(
   );
 }
 
+async function handleScoreDocument(
+  env: Env,
+  request: Request,
+  projectId: string,
+  docId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const doc = await env.DB.prepare(
+    "SELECT id, project_id, title, current_revision, r2_key FROM documents WHERE id = ? AND project_id = ?",
+  )
+    .bind(docId, projectId)
+    .first<Document>();
+
+  if (!doc) return error("Document not found", 404);
+
+  const apiKey = getApiKey(env, request);
+  if (!apiKey)
+    return error("API key required. Set ANTHROPIC_API_KEY or pass x-anthropic-key header.", 400);
+
+  // Fetch document content from R2
+  const object = await env.CONTENT_BUCKET.get(doc.r2_key);
+  const content = object ? await object.text() : "";
+  if (!content.trim()) return error("Document is empty", 400);
+
+  // Run calibrated scoring via review-panel
+  const documentScore = await scoreDocument(
+    content,
+    docId,
+    doc.current_revision,
+    (prompt: string) =>
+      callClaudeAPI(prompt, apiKey, {
+        maxTokens: 4096,
+        gatewayUrl: getGatewayUrl(env),
+        gatewayToken: env.AI_GATEWAY_TOKEN,
+      }),
+  );
+
+  // Persist to document_scores table
+  const now = new Date().toISOString();
+  await env.DB.prepare(
+    "INSERT INTO document_scores (id, document_id, revision_number, overall_score, model, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  )
+    .bind(
+      documentScore.id,
+      docId,
+      doc.current_revision,
+      documentScore.overallScore,
+      documentScore.model,
+      now,
+    )
+    .run();
+
+  // Persist dimension scores
+  for (const dim of documentScore.dimensions) {
+    const dimId = crypto.randomUUID();
+    await env.DB.prepare(
+      "INSERT INTO dimension_scores (id, document_score_id, dimension_id, score, justification) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(dimId, documentScore.id, dim.dimensionId, dim.score, dim.justification)
+      .run();
+
+    // Persist weaknesses
+    for (const weakness of dim.weaknesses) {
+      const weaknessId = crypto.randomUUID();
+      await env.DB.prepare(
+        "INSERT INTO dimension_weaknesses (id, dimension_score_id, description, evidence) VALUES (?, ?, ?, ?)",
+      )
+        .bind(weaknessId, dimId, weakness.description, weakness.evidence)
+        .run();
+    }
+  }
+
+  return json(documentScore, 201);
+}
+
+async function handleGetScores(
+  env: Env,
+  projectId: string,
+  docId: string,
+  userId: string,
+): Promise<Response> {
+  if (!(await verifyProjectOwnership(env, projectId, userId))) {
+    return error("Project not found", 404);
+  }
+
+  const { results: scores } = await env.DB.prepare(
+    "SELECT ds.id, ds.document_id, ds.revision_number, ds.overall_score, ds.model, ds.created_at FROM document_scores ds JOIN documents d ON ds.document_id = d.id WHERE d.id = ? AND d.project_id = ? ORDER BY ds.created_at DESC",
+  )
+    .bind(docId, projectId)
+    .all<{
+      id: string;
+      document_id: string;
+      revision_number: number;
+      overall_score: number;
+      model: string;
+      created_at: string;
+    }>();
+
+  // Enrich each score with dimension details
+  const enrichedScores = [];
+  for (const score of scores) {
+    const { results: dimensions } = await env.DB.prepare(
+      "SELECT id, dimension_id, score, justification FROM dimension_scores WHERE document_score_id = ?",
+    )
+      .bind(score.id)
+      .all<{
+        id: string;
+        dimension_id: string;
+        score: number;
+        justification: string;
+      }>();
+
+    const dimensionsWithWeaknesses = [];
+    for (const dim of dimensions) {
+      const { results: weaknesses } = await env.DB.prepare(
+        "SELECT description, evidence FROM dimension_weaknesses WHERE dimension_score_id = ?",
+      )
+        .bind(dim.id)
+        .all<{ description: string; evidence: string }>();
+
+      dimensionsWithWeaknesses.push({
+        dimensionId: dim.dimension_id,
+        score: dim.score,
+        justification: dim.justification,
+        weaknesses,
+      });
+    }
+
+    enrichedScores.push({
+      ...score,
+      dimensions: dimensionsWithWeaknesses,
+    });
+  }
+
+  return json({ scores: enrichedScores });
+}
+
 // Main request handler
 export const onRequest: PagesFunction<Env> = async (context) => {
   const { request, env, params } = context;
@@ -1598,6 +1843,21 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       const user = await getAuthenticatedUser(env, request);
       if (!user) return error("Unauthorized", 401);
       return handleGenerateRefinement(env, request, refineMatch[1], refineMatch[2], user.id);
+    }
+
+    // Scoring endpoints
+    const scoreMatch = path.match(/^\/api\/projects\/([^/]+)\/documents\/([^/]+)\/ai\/score$/);
+    if (scoreMatch && method === "POST") {
+      const user = await getAuthenticatedUser(env, request);
+      if (!user) return error("Unauthorized", 401);
+      return handleScoreDocument(env, request, scoreMatch[1], scoreMatch[2], user.id);
+    }
+
+    const scoresListMatch = path.match(/^\/api\/projects\/([^/]+)\/documents\/([^/]+)\/scores$/);
+    if (scoresListMatch && method === "GET") {
+      const user = await getAuthenticatedUser(env, request);
+      if (!user) return error("Unauthorized", 401);
+      return handleGetScores(env, scoresListMatch[1], scoresListMatch[2], user.id);
     }
 
     // Voice profile endpoints (require authentication)

--- a/src/components/ReviewPanel.tsx
+++ b/src/components/ReviewPanel.tsx
@@ -8,6 +8,7 @@ interface ReviewItem {
   description: string;
   severity: "error" | "warning" | "suggestion";
   location: string | null;
+  suggestion: string | null;
   status: "open" | "addressed" | "partial" | "dismissed";
 }
 
@@ -17,6 +18,12 @@ interface Review {
   revision_number: number;
   summary: string;
   created_at: string;
+}
+
+interface StyleguideInfo {
+  score: number;
+  totalIssues: number;
+  counts: Record<string, number>;
 }
 
 interface RevisionResult {
@@ -62,6 +69,7 @@ export function ReviewPanel({
 }: ReviewPanelProps) {
   const [review, setReview] = useState<Review | null>(null);
   const [items, setItems] = useState<ReviewItem[]>([]);
+  const [styleguide, setStyleguide] = useState<StyleguideInfo | null>(null);
   const [isReviewing, setIsReviewing] = useState(false);
   const [isRevising, setIsRevising] = useState(false);
   const [isRefining, setIsRefining] = useState(false);
@@ -86,6 +94,9 @@ export function ReviewPanel({
       const data = await response.json();
       setReview(data.review);
       setItems(data.items);
+      if (data.styleguide) {
+        setStyleguide(data.styleguide);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate review");
     } finally {
@@ -259,6 +270,60 @@ export function ReviewPanel({
               <p className="text-sm text-muted-foreground">{review.summary}</p>
             </div>
 
+            {/* Styleguide Score */}
+            {styleguide && (
+              <div className="mb-4 rounded-md border p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Styleguide Score
+                  </span>
+                  <span
+                    className={`text-sm font-semibold ${
+                      styleguide.score <= 2
+                        ? "text-green-600 dark:text-green-400"
+                        : styleguide.score <= 5
+                          ? "text-yellow-600 dark:text-yellow-400"
+                          : "text-red-600 dark:text-red-400"
+                    }`}
+                  >
+                    {styleguide.score.toFixed(1)}/10
+                  </span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+                  <div
+                    className={`h-1.5 rounded-full ${
+                      styleguide.score <= 2
+                        ? "bg-green-500"
+                        : styleguide.score <= 5
+                          ? "bg-yellow-500"
+                          : "bg-red-500"
+                    }`}
+                    style={{ width: `${Math.min(styleguide.score * 10, 100)}%` }}
+                  />
+                </div>
+                {styleguide.totalIssues > 0 && (
+                  <div className="mt-2 flex gap-2 text-xs text-muted-foreground">
+                    {styleguide.counts.error > 0 && (
+                      <span className="text-red-600 dark:text-red-400">
+                        {styleguide.counts.error} errors
+                      </span>
+                    )}
+                    {styleguide.counts.warning > 0 && (
+                      <span className="text-yellow-600 dark:text-yellow-400">
+                        {styleguide.counts.warning} warnings
+                      </span>
+                    )}
+                    {(styleguide.counts.info > 0 || styleguide.counts.suggestion > 0) && (
+                      <span>
+                        {(styleguide.counts.info || 0) + (styleguide.counts.suggestion || 0)}{" "}
+                        suggestions
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Progress */}
             <div className="mb-4 flex items-center gap-3 text-xs">
               <span className="rounded-full bg-gray-100 px-2 py-0.5 dark:bg-gray-800">
@@ -318,6 +383,9 @@ export function ReviewPanel({
                     </span>
                   </div>
                   <p className="text-sm">{item.description}</p>
+                  {item.suggestion && (
+                    <p className="mt-1 text-xs text-muted-foreground italic">{item.suggestion}</p>
+                  )}
                   {item.status !== "dismissed" && item.status !== "addressed" && (
                     <div className="mt-2 flex gap-1">
                       <button


### PR DESCRIPTION
## Summary
Integrates the existing `@draftwell/styleguide` and `@draftwell/review-panel` packages into the live API pipeline, completing the MVP deliverables for "Basic styleguide with anti-trope validation" and "Critical review generation."

## Changes
- **Phase 1 – Styleguide**: Import `check()` and `defaultStyleguide` into `handleGenerateReview`; run pure-regex styleguide check on every review; return slop score + violation counts in the API response
- **Phase 2 – Multi-persona review**: Replace single-pass chunk-based review with `reviewDocument()` from review-panel, running 4 personas in parallel via `callClaudeAPI`; map persona severity (critical/major/minor/suggestion) to API severity (error/warning/suggestion); wire user voice profile for personalized feedback
- **Phase 3 – Scoring**: Add `POST /ai/score` endpoint using `scoreDocument()` with persistence to `document_scores`, `dimension_scores`, and `dimension_weaknesses` tables; add `GET /scores` endpoint for score history with dimension details
- **ReviewPanel UI**: Add styleguide score progress bar with color-coded thresholds; display suggestion text on review items

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Styleguide check runs on document content | ✅ | `check(content, defaultStyleguide)` called in handleGenerateReview |
| Styleguide violations returned in review response | ✅ | Response includes `styleguide` field with score, totalIssues, counts + violations as review_items |
| Multi-persona review replaces single-pass | ✅ | `reviewDocument()` replaces chunk-based loop; consensus clusters stored as review_items |
| callClaudeAPI wired as callModel | ✅ | Lambda passed to reviewDocument options |
| Score endpoint persists to DB tables | ✅ | POST /ai/score writes to document_scores, dimension_scores, dimension_weaknesses |
| Score retrieval endpoint works | ✅ | GET /scores returns enriched scores with dimension details |
| ReviewPanel displays styleguide results | ✅ | Score bar with green/yellow/red thresholds + counts |
| No breaking changes to existing response shape | ✅ | `review` and `items` fields preserved; `styleguide` field is additive |
| Voice profile integration | ✅ | User's most recent voice profile fetched and passed to reviewDocument |

## Test Plan
- `pnpm vitest run` — 194 tests pass (6 pre-existing test suite failures in review-panel package unrelated to this change)
- `pnpm biome check` on changed files — clean
- Verified import paths resolve correctly for both packages

Closes #51