### PR TITLE
fix: exclude review-panel from vitest test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
     include: ["**/__tests__/**/*.test.{ts,tsx}", "**/*.test.{ts,tsx}"],
-    exclude: ["**/node_modules/**", ".loom/worktrees/**"],
+    exclude: ["**/node_modules/**", ".loom/worktrees/**", "packages/review-panel/**"],
     testTimeout: 10000,
     hookTimeout: 10000,
     coverage: {


### PR DESCRIPTION
## Summary
Excludes the `packages/review-panel/**` directory from vitest's test discovery. The review-panel package uses Node's built-in test runner (`node:test`), not vitest, so vitest incorrectly reports 6 "No test suite found" failures.

## Changes
- Added `"packages/review-panel/**"` to the `exclude` array in `vitest.config.ts`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm test` reports 0 failures | ✅ | Ran `pnpm test` — 15 passed, 0 failed (previously 6 failed) |
| All 194 actual tests still pass | ✅ | 194 tests passed |
| review-panel tests unaffected | ✅ | `cd packages/review-panel && pnpm test` runs independently |

## Test Plan
- Ran `pnpm test` before and after: failures dropped from 6 to 0
- Verified review-panel's own `pnpm test` (node --test) still works independently

Closes #50