### PR TITLE
style: apply biome formatting and import ordering fixes

### DIFF
--- a/functions/lib/auth.ts
+++ b/functions/lib/auth.ts
@@ -1,12 +1,12 @@
-import type { Env, User } from "./types";
 import {
-  json,
-  error,
-  setSessionCookie,
   clearSessionCookie,
+  error,
   getSessionIdFromCookie,
+  json,
   SESSION_DURATION_MS,
+  setSessionCookie,
 } from "./shared";
+import type { Env, User } from "./types";
 
 // Password hashing using PBKDF2 (edge-compatible, more secure than plain SHA-256)
 async function hashPassword(
@@ -207,7 +207,7 @@ export async function handleUpdateMe(env: Env, request: Request): Promise<Respon
   const body = (await request.json()) as { name?: string };
   const { name } = body;
 
-  if (!name || !name.trim()) {
+  if (!name?.trim()) {
     return error("Name is required");
   }
 
@@ -225,9 +225,7 @@ export async function handleDeleteMe(env: Env, request: Request): Promise<Respon
   // Delete user — cascades to sessions, projects, documents, reviews, revisions
   // via ON DELETE CASCADE foreign keys.
   // Also clean up R2 objects for the user's documents and reviews.
-  const { results: projects } = await env.DB.prepare(
-    "SELECT id FROM projects WHERE user_id = ?",
-  )
+  const { results: projects } = await env.DB.prepare("SELECT id FROM projects WHERE user_id = ?")
     .bind(user.id)
     .all<{ id: string }>();
 

--- a/functions/lib/documents.ts
+++ b/functions/lib/documents.ts
@@ -1,8 +1,12 @@
-import type { Env, Document } from "./types";
-import { json, error } from "./shared";
 import { verifyProjectOwnership } from "./projects";
+import { error, json } from "./shared";
+import type { Document, Env } from "./types";
 
-export async function handleGetDocuments(env: Env, projectId: string, userId: string): Promise<Response> {
+export async function handleGetDocuments(
+  env: Env,
+  projectId: string,
+  userId: string,
+): Promise<Response> {
   if (!(await verifyProjectOwnership(env, projectId, userId))) {
     return error("Project not found", 404);
   }

--- a/functions/lib/projects.ts
+++ b/functions/lib/projects.ts
@@ -1,5 +1,5 @@
+import { error, json } from "./shared";
 import type { Env, Project } from "./types";
-import { json, error } from "./shared";
 
 export async function verifyProjectOwnership(
   env: Env,
@@ -34,7 +34,11 @@ export async function handleGetProject(env: Env, id: string, userId: string): Pr
   return json({ project });
 }
 
-export async function handleCreateProject(env: Env, request: Request, userId: string): Promise<Response> {
+export async function handleCreateProject(
+  env: Env,
+  request: Request,
+  userId: string,
+): Promise<Response> {
   const body = (await request.json()) as { name?: string; description?: string };
   const { name, description } = body;
 

--- a/functions/lib/voice.ts
+++ b/functions/lib/voice.ts
@@ -1,5 +1,5 @@
+import { error, json } from "./shared";
 import type { Env, VoiceProfile, VoiceSample } from "./types";
-import { json, error } from "./shared";
 
 const VOICE_DIMENSIONS = [
   "Sentence structure and length patterns",
@@ -107,7 +107,11 @@ export async function handleDeleteVoiceProfile(
   return json({ success: true });
 }
 
-export async function handleAnalyzeVoice(env: Env, request: Request, userId: string): Promise<Response> {
+export async function handleAnalyzeVoice(
+  env: Env,
+  request: Request,
+  userId: string,
+): Promise<Response> {
   const body = (await request.json()) as {
     samples: Array<{ text: string; source_url?: string }>;
     name?: string;

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -141,7 +141,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, logout, register, updateProfile, deleteAccount }}>
+    <AuthContext.Provider
+      value={{ user, isLoading, login, logout, register, updateProfile, deleteAccount }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -47,12 +47,9 @@ function addPageNumber(state: PdfState): void {
   state.doc.setFontSize(FONT_SIZES.small);
   state.doc.setFont("helvetica", "normal");
   state.doc.setTextColor(150, 150, 150);
-  state.doc.text(
-    `${state.pageNumber}`,
-    state.pageWidth / 2,
-    state.pageHeight - 10,
-    { align: "center" },
-  );
+  state.doc.text(`${state.pageNumber}`, state.pageWidth / 2, state.pageHeight - 10, {
+    align: "center",
+  });
   state.doc.setTextColor(0, 0, 0);
 }
 
@@ -90,8 +87,7 @@ function renderHeading(state: PdfState, token: Tokens.Heading): void {
   const depth = token.depth as 1 | 2 | 3 | 4;
   const sizeKey = depth <= 4 ? (`h${depth}` as keyof typeof FONT_SIZES) : "h4";
   const fontSize = FONT_SIZES[sizeKey];
-  const lineHeight =
-    LINE_HEIGHTS[sizeKey as keyof typeof LINE_HEIGHTS] ?? LINE_HEIGHTS.body;
+  const lineHeight = LINE_HEIGHTS[sizeKey as keyof typeof LINE_HEIGHTS] ?? LINE_HEIGHTS.body;
 
   state.y += HEADER_SPACE;
   ensureSpace(state, lineHeight + 4);
@@ -103,12 +99,7 @@ function renderHeading(state: PdfState, token: Tokens.Heading): void {
   if (depth <= 2) {
     state.doc.setDrawColor(200, 200, 200);
     state.doc.setLineWidth(depth === 1 ? 0.5 : 0.3);
-    state.doc.line(
-      state.margin,
-      state.y - 1,
-      state.margin + state.contentWidth,
-      state.y - 1,
-    );
+    state.doc.line(state.margin, state.y - 1, state.margin + state.contentWidth, state.y - 1);
     state.y += 3;
   }
 
@@ -132,14 +123,7 @@ function renderList(state: PdfState, token: Tokens.List): void {
     state.doc.setFont("helvetica", "normal");
     state.doc.text(bullet, state.margin + 4, state.y);
 
-    renderWrappedText(
-      state,
-      text,
-      FONT_SIZES.body,
-      LINE_HEIGHTS.body,
-      "normal",
-      12,
-    );
+    renderWrappedText(state, text, FONT_SIZES.body, LINE_HEIGHTS.body, "normal", 12);
     state.y += 1;
   }
   state.y += PARAGRAPH_SPACE;
@@ -158,13 +142,7 @@ function renderCode(state: PdfState, token: Tokens.Code): void {
   state.doc.setFillColor(245, 245, 245);
   const remainingHeight = state.pageHeight - MARGIN - 15 - state.y;
   const bgHeight = Math.min(blockHeight, remainingHeight);
-  state.doc.rect(
-    state.margin,
-    state.y - 2,
-    state.contentWidth,
-    bgHeight,
-    "F",
-  );
+  state.doc.rect(state.margin, state.y - 2, state.contentWidth, bgHeight, "F");
 
   state.doc.setFontSize(9);
   state.doc.setFont("courier", "normal");
@@ -194,14 +172,7 @@ function renderBlockquote(state: PdfState, token: Tokens.Blockquote): void {
     .join("\n");
 
   state.doc.setTextColor(100, 100, 100);
-  renderWrappedText(
-    state,
-    text,
-    FONT_SIZES.body,
-    LINE_HEIGHTS.body,
-    "italic",
-    10,
-  );
+  renderWrappedText(state, text, FONT_SIZES.body, LINE_HEIGHTS.body, "italic", 10);
   state.doc.setTextColor(0, 0, 0);
 
   state.doc.line(state.margin + 3, startY - 2, state.margin + 3, state.y);
@@ -213,12 +184,7 @@ function renderHr(state: PdfState): void {
   ensureSpace(state, 8);
   state.doc.setDrawColor(200, 200, 200);
   state.doc.setLineWidth(0.3);
-  state.doc.line(
-    state.margin,
-    state.y,
-    state.margin + state.contentWidth,
-    state.y,
-  );
+  state.doc.line(state.margin, state.y, state.margin + state.contentWidth, state.y);
   state.y += 8;
 }
 
@@ -334,12 +300,9 @@ export function exportToPdf(markdown: string, title: string): void {
   state.y += 12;
 
   // Handle image placeholders by pre-processing
-  const processedMarkdown = markdown.replace(
-    /!\[([^\]]*)\]\([^)]+\)/g,
-    (_match, alt) => {
-      return `<!--img:${alt}-->`;
-    },
-  );
+  const processedMarkdown = markdown.replace(/!\[([^\]]*)\]\([^)]+\)/g, (_match, alt) => {
+    return `<!--img:${alt}-->`;
+  });
 
   // Tokenize markdown
   const lexer = new Lexer();

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -115,9 +115,7 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{projects.length}</div>
-            <p className="text-xs text-muted-foreground">
-              {activeProjects} active
-            </p>
+            <p className="text-xs text-muted-foreground">{activeProjects} active</p>
           </CardContent>
         </Card>
         <Card>
@@ -126,9 +124,7 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{documentCount}</div>
-            <p className="text-xs text-muted-foreground">
-              Across all projects
-            </p>
+            <p className="text-xs text-muted-foreground">Across all projects</p>
           </CardContent>
         </Card>
         <Card>

--- a/src/pages/DocumentEditPage.tsx
+++ b/src/pages/DocumentEditPage.tsx
@@ -1,6 +1,6 @@
+import { Download } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Download } from "lucide-react";
 import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MarkdownPreview } from "@/components/MarkdownPreview";
 import { ReviewPanel } from "@/components/ReviewPanel";
@@ -200,7 +200,9 @@ export function DocumentEditPage() {
         {/* Editor area */}
         <div className={`flex min-h-0 ${showReview ? "w-2/3" : "w-full"}`}>
           {viewMode !== "preview" && (
-            <div className={`min-h-0 ${viewMode === "split" ? "w-1/2 border-r border-border/50" : "w-full"}`}>
+            <div
+              className={`min-h-0 ${viewMode === "split" ? "w-1/2 border-r border-border/50" : "w-full"}`}
+            >
               <MarkdownEditor value={content} onChange={handleChange} />
             </div>
           )}

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -286,9 +286,7 @@ export function ProjectDetailPage() {
                       {doc.updated_at !== doc.created_at && (
                         <> • Updated {new Date(doc.updated_at).toLocaleDateString()}</>
                       )}
-                      {doc.current_revision > 0 && (
-                        <> • Rev {doc.current_revision}</>
-                      )}
+                      {doc.current_revision > 0 && <> • Rev {doc.current_revision}</>}
                     </div>
                   </Link>
                   <ConfirmDialog


### PR DESCRIPTION
## Summary
Apply biome auto-fix across the codebase to resolve all lint and formatting warnings. All changes are purely cosmetic — import reordering, line wrapping, and one optional chaining simplification.

## Changes
- Reorder imports alphabetically in 6 files (auth.ts, documents.ts, projects.ts, voice.ts, DocumentEditPage.tsx)
- Reformat long function signatures and JSX props across 9 files
- Simplify `!name || !name.trim()` to `!name?.trim()` in auth.ts

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm biome check src/ functions/ packages/` exits with 0 errors | ✅ | Ran biome check — "Checked 51 files. No fixes applied." |
| `pnpm check:ci` passes cleanly | ✅ | All 115 tests pass, tsc and biome clean |
| No functional code changes — only formatting and import ordering | ✅ | Reviewed full diff — only whitespace, import order, line wrapping, and optional chaining |

## Test Plan
- `pnpm biome check src/ functions/ packages/` — 0 errors
- `pnpm check:ci` — tsc, biome, and all 115 tests pass

Closes #69