### PR TITLE
feat: add Google OAuth sign-in with identity linking

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -29,6 +29,7 @@ import {
   handleGetDocuments,
   handleUpdateDocument,
 } from "../lib/documents";
+import { handleGoogleAuth, handleGoogleCallback } from "../lib/google-auth";
 import {
   handleCreateProject,
   handleDeleteProject,
@@ -87,6 +88,15 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
     if (path === "/api/auth/refresh" && method === "POST") {
       return handleRefreshSession(env, request);
+    }
+
+    // Google OAuth (redirect-based flow)
+    if (path === "/api/auth/google" && method === "GET") {
+      return handleGoogleAuth(env, request);
+    }
+
+    if (path === "/api/auth/google/callback" && method === "GET") {
+      return handleGoogleCallback(env, request);
     }
 
     // Projects endpoints (require authentication via session cookie)

--- a/functions/lib/__tests__/google-auth.test.ts
+++ b/functions/lib/__tests__/google-auth.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleLogin } from "../auth";
+import { handleGoogleAuth, handleGoogleCallback } from "../google-auth";
+import type { Env } from "../types";
+
+const CLIENT_ID = "test-client-id.apps.googleusercontent.com";
+const CLIENT_SECRET = "test-client-secret";
+
+// Base64url-encode an object (JWT segment style).
+function b64url(obj: unknown): string {
+  return btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// Build a fake (unsigned) Google ID token with the given payload.
+function makeIdToken(payload: Record<string, unknown>): string {
+  return `${b64url({ alg: "RS256", typ: "JWT" })}.${b64url(payload)}.signature`;
+}
+
+function defaultPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    sub: "google-sub-123",
+    email: "user@example.com",
+    email_verified: true,
+    name: "Test User",
+    aud: CLIENT_ID,
+    iss: "https://accounts.google.com",
+    ...overrides,
+  };
+}
+
+interface DbState {
+  oauthLink: { user_id: string } | null;
+  userByEmail: { id: string } | null;
+  insertedUsers: unknown[][];
+  insertedLinks: unknown[][];
+  sessions: unknown[][];
+}
+
+function makeDb(state: Partial<DbState> = {}): { db: D1Database; state: DbState } {
+  const s: DbState = {
+    oauthLink: state.oauthLink ?? null,
+    userByEmail: state.userByEmail ?? null,
+    insertedUsers: [],
+    insertedLinks: [],
+    sessions: [],
+  };
+
+  const db = {
+    prepare(sql: string) {
+      let boundArgs: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          boundArgs = args;
+          return stmt;
+        },
+        async first() {
+          if (sql.includes("FROM oauth_accounts WHERE provider")) {
+            return s.oauthLink;
+          }
+          if (sql.includes("FROM users WHERE email")) {
+            return s.userByEmail;
+          }
+          return null;
+        },
+        async run() {
+          if (sql.startsWith("INSERT INTO users")) s.insertedUsers.push(boundArgs);
+          if (sql.startsWith("INSERT INTO oauth_accounts")) s.insertedLinks.push(boundArgs);
+          if (sql.startsWith("INSERT INTO sessions")) s.sessions.push(boundArgs);
+          return { success: true };
+        },
+        async all() {
+          return { results: [] };
+        },
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+
+  return { db, state: s };
+}
+
+function makeEnv(db: D1Database, configured = true): Env {
+  return {
+    DB: db,
+    APP_NAME: "test-app",
+    GOOGLE_CLIENT_ID: configured ? CLIENT_ID : undefined,
+    GOOGLE_CLIENT_SECRET: configured ? CLIENT_SECRET : undefined,
+  } as unknown as Env;
+}
+
+function callbackRequest(opts: { state?: string; cookieState?: string; error?: string }): Request {
+  const params = new URLSearchParams();
+  if (opts.error) params.set("error", opts.error);
+  if (opts.state) params.set("state", opts.state);
+  if (opts.state) params.set("code", "auth-code-abc");
+  const url = `https://draftwell.org/api/auth/google/callback?${params.toString()}`;
+  const headers: Record<string, string> = {};
+  if (opts.cookieState) headers.Cookie = `draftwell-oauth-state=${opts.cookieState}`;
+  return new Request(url, { headers });
+}
+
+function mockTokenEndpoint(payload: Record<string, unknown>, ok = true) {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(ok ? { id_token: makeIdToken(payload) } : { error: "bad" }), {
+      status: ok ? 200 : 400,
+    }),
+  ) as typeof fetch;
+}
+
+describe("handleGoogleAuth", () => {
+  it("returns 503 when Google secrets are not configured", async () => {
+    const { db } = makeDb();
+    const res = await handleGoogleAuth(
+      makeEnv(db, false),
+      new Request("https://draftwell.org/api/auth/google"),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("redirects to Google with state cookie when configured", async () => {
+    const { db } = makeDb();
+    const res = await handleGoogleAuth(
+      makeEnv(db),
+      new Request("https://draftwell.org/api/auth/google"),
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(location).toContain(`client_id=${encodeURIComponent(CLIENT_ID)}`);
+    expect(location).toContain("scope=openid+email+profile");
+    expect(location).toContain("state=");
+    expect(location).toContain(
+      "redirect_uri=https%3A%2F%2Fdraftwell.org%2Fapi%2Fauth%2Fgoogle%2Fcallback",
+    );
+
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("draftwell-oauth-state=");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+  });
+});
+
+describe("handleGoogleCallback", () => {
+  const STATE = "state-token-xyz";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 503 when Google secrets are not configured", async () => {
+    const { db } = makeDb();
+    const res = await handleGoogleCallback(
+      makeEnv(db, false),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 400 when state does not match the cookie", async () => {
+    const { db } = makeDb();
+    mockTokenEndpoint(defaultPayload());
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: "different-state" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the state cookie is missing", async () => {
+    const { db } = makeDb();
+    const res = await handleGoogleCallback(makeEnv(db), callbackRequest({ state: STATE }));
+    expect(res.status).toBe(400);
+  });
+
+  it("redirects to /login?error=oauth when the user denies consent", async () => {
+    const { db } = makeDb();
+    const req = callbackRequest({ error: "access_denied", cookieState: STATE });
+    const res = await handleGoogleCallback(makeEnv(db), req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/login?error=oauth");
+  });
+
+  it("creates a new passwordless user and session on first sign-in", async () => {
+    const { db, state } = makeDb({ oauthLink: null, userByEmail: null });
+    mockTokenEndpoint(defaultPayload());
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/dashboard");
+    expect(res.headers.get("Set-Cookie")).toContain("draftwell-session=");
+
+    // One new user, one oauth link, one session created.
+    expect(state.insertedUsers).toHaveLength(1);
+    expect(state.insertedLinks).toHaveLength(1);
+    expect(state.sessions).toHaveLength(1);
+    // The user was inserted with the Google email and derived name.
+    expect(state.insertedUsers[0]).toContain("user@example.com");
+  });
+
+  it("logs into the existing account matched by Google sub (not email)", async () => {
+    const { db, state } = makeDb({ oauthLink: { user_id: "existing-user-1" } });
+    mockTokenEndpoint(defaultPayload());
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    // No new user or link — logged into the linked account.
+    expect(state.insertedUsers).toHaveLength(0);
+    expect(state.insertedLinks).toHaveLength(0);
+    expect(state.sessions).toHaveLength(1);
+    expect(state.sessions[0]).toContain("existing-user-1");
+  });
+
+  it("links to an existing email account only when email_verified is true", async () => {
+    const { db, state } = makeDb({ userByEmail: { id: "pw-user-1" } });
+    mockTokenEndpoint(defaultPayload({ email_verified: true }));
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(state.insertedUsers).toHaveLength(0);
+    expect(state.insertedLinks).toHaveLength(1);
+    expect(state.insertedLinks[0]).toContain("pw-user-1");
+    expect(state.sessions[0]).toContain("pw-user-1");
+  });
+
+  it("refuses to link an email account when email_verified is false (403)", async () => {
+    const { db, state } = makeDb({ userByEmail: { id: "pw-user-1" } });
+    mockTokenEndpoint(defaultPayload({ email_verified: false }));
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(state.insertedLinks).toHaveLength(0);
+    expect(state.sessions).toHaveLength(0);
+  });
+
+  it("rejects a token whose audience is not our client id", async () => {
+    const { db } = makeDb({ oauthLink: null, userByEmail: null });
+    mockTokenEndpoint(defaultPayload({ aud: "someone-else" }));
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/login?error=oauth");
+  });
+
+  it("rejects a token with an invalid issuer", async () => {
+    const { db } = makeDb({ oauthLink: null, userByEmail: null });
+    mockTokenEndpoint(defaultPayload({ iss: "https://evil.example.com" }));
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/login?error=oauth");
+  });
+
+  it("falls back to the email local-part when Google omits the name claim", async () => {
+    const { db, state } = makeDb({ oauthLink: null, userByEmail: null });
+    mockTokenEndpoint(
+      defaultPayload({ name: undefined, email: "alice@example.com", sub: "sub-a" }),
+    );
+
+    const res = await handleGoogleCallback(
+      makeEnv(db),
+      callbackRequest({ state: STATE, cookieState: STATE }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(state.insertedUsers[0]).toContain("alice");
+  });
+});
+
+describe("handleLogin — Google-only account guard", () => {
+  it("returns 401 (not 500) when the account has a null password_hash", async () => {
+    const db = {
+      prepare() {
+        const stmt = {
+          bind() {
+            return stmt;
+          },
+          async first() {
+            return {
+              id: "google-user-1",
+              email: "user@example.com",
+              name: "Test User",
+              password_hash: null,
+              created_at: "2024-01-01",
+            };
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+        return stmt;
+      },
+    } as unknown as D1Database;
+
+    const env = makeEnv(db);
+    const request = new Request("https://draftwell.org/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", password: "whatever123" }),
+    });
+
+    const res = await handleLogin(env, request);
+    expect(res.status).toBe(401);
+  });
+});

--- a/functions/lib/auth.ts
+++ b/functions/lib/auth.ts
@@ -57,7 +57,7 @@ async function verifyPassword(password: string, storedHash: string): Promise<boo
 }
 
 // Session management
-async function createSession(env: Env, userId: string): Promise<string> {
+export async function createSession(env: Env, userId: string): Promise<string> {
   const sessionId = crypto.randomUUID();
   const expiresAt = new Date(Date.now() + SESSION_DURATION_MS).toISOString();
 
@@ -117,9 +117,15 @@ export async function handleLogin(env: Env, request: Request): Promise<Response>
     "SELECT id, email, name, password_hash, created_at FROM users WHERE email = ?",
   )
     .bind(email)
-    .first<User & { password_hash: string }>();
+    .first<User & { password_hash: string | null }>();
 
   if (!user) {
+    return error("Invalid email or password", 401);
+  }
+
+  // Google-only accounts have a null password_hash — password login must fail
+  // cleanly (401) rather than crashing verifyPassword (500).
+  if (!user.password_hash) {
     return error("Invalid email or password", 401);
   }
 

--- a/functions/lib/google-auth.ts
+++ b/functions/lib/google-auth.ts
@@ -1,0 +1,242 @@
+// Google OAuth 2.0 (authorization code grant) for Cloudflare Pages Functions.
+//
+// Flow:
+//   GET /api/auth/google           -> 302 to Google's consent screen, sets a
+//                                     short-lived state cookie (CSRF protection).
+//   GET /api/auth/google/callback  -> verifies state, exchanges the code for
+//                                     tokens, resolves/creates the local user,
+//                                     establishes a session, then 302 to /dashboard.
+//
+// Deployment prerequisite (operator): create a Google Cloud OAuth 2.0 web client
+// and set GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET via `wrangler secret put`.
+// Code and tests do not depend on live credentials.
+
+import { createSession } from "./auth";
+import {
+  clearStateCookie,
+  error,
+  getStateFromCookie,
+  SESSION_DURATION_MS,
+  setSessionCookie,
+  setStateCookie,
+} from "./shared";
+import type { Env } from "./types";
+
+const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_SCOPES = "openid email profile";
+const PROVIDER = "google";
+const VALID_ISSUERS = ["https://accounts.google.com", "accounts.google.com"];
+
+interface GoogleIdTokenPayload {
+  sub?: string;
+  email?: string;
+  email_verified?: boolean | string;
+  name?: string;
+  aud?: string;
+  iss?: string;
+}
+
+function isConfigured(env: Env): boolean {
+  return Boolean(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET);
+}
+
+function callbackRedirectUri(request: Request): string {
+  return new URL("/api/auth/google/callback", request.url).toString();
+}
+
+// Base64url-decode a JWT payload segment. The ID token comes directly from
+// Google over TLS, so signature verification is optional here — but we still
+// validate `aud` and `iss` in the callback.
+function decodeIdTokenPayload(idToken: string): GoogleIdTokenPayload {
+  const parts = idToken.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed ID token");
+  }
+  const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  const decoded = atob(padded);
+  return JSON.parse(decoded) as GoogleIdTokenPayload;
+}
+
+function redirectToLoginError(request: Request): Response {
+  const location = new URL("/login?error=oauth", request.url).toString();
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location, "Set-Cookie": clearStateCookie() },
+  });
+}
+
+// GET /api/auth/google — begin the OAuth dance.
+export async function handleGoogleAuth(env: Env, request: Request): Promise<Response> {
+  if (!isConfigured(env)) {
+    return error("Google sign-in is not configured", 503);
+  }
+
+  const state = crypto.randomUUID();
+  const params = new URLSearchParams({
+    client_id: env.GOOGLE_CLIENT_ID as string,
+    redirect_uri: callbackRedirectUri(request),
+    response_type: "code",
+    scope: GOOGLE_SCOPES,
+    state,
+    access_type: "online",
+    prompt: "select_account",
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${GOOGLE_AUTH_ENDPOINT}?${params.toString()}`,
+      "Set-Cookie": setStateCookie(state),
+    },
+  });
+}
+
+// GET /api/auth/google/callback — complete the OAuth dance and sign the user in.
+export async function handleGoogleCallback(env: Env, request: Request): Promise<Response> {
+  if (!isConfigured(env)) {
+    return error("Google sign-in is not configured", 503);
+  }
+
+  const url = new URL(request.url);
+
+  // User denied consent (or Google returned an error) → back to login.
+  if (url.searchParams.get("error")) {
+    return redirectToLoginError(request);
+  }
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const expectedState = getStateFromCookie(request);
+
+  // CSRF check: the state echoed by Google must match the cookie we set.
+  if (!state || !expectedState || state !== expectedState) {
+    return error("Invalid OAuth state", 400);
+  }
+
+  if (!code) {
+    return error("Missing authorization code", 400);
+  }
+
+  // Exchange the authorization code for tokens.
+  let payload: GoogleIdTokenPayload;
+  try {
+    const tokenResponse = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        code,
+        client_id: env.GOOGLE_CLIENT_ID as string,
+        client_secret: env.GOOGLE_CLIENT_SECRET as string,
+        redirect_uri: callbackRedirectUri(request),
+        grant_type: "authorization_code",
+      }).toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      return redirectToLoginError(request);
+    }
+
+    const tokenData = (await tokenResponse.json()) as { id_token?: string };
+    if (!tokenData.id_token) {
+      return redirectToLoginError(request);
+    }
+
+    payload = decodeIdTokenPayload(tokenData.id_token);
+  } catch {
+    return redirectToLoginError(request);
+  }
+
+  // Validate token audience and issuer.
+  if (
+    payload.aud !== env.GOOGLE_CLIENT_ID ||
+    !payload.iss ||
+    !VALID_ISSUERS.includes(payload.iss)
+  ) {
+    return redirectToLoginError(request);
+  }
+
+  const sub = payload.sub;
+  const email = payload.email;
+  if (!sub || !email) {
+    return redirectToLoginError(request);
+  }
+
+  // Google reports email_verified as a boolean, but some flows stringify it.
+  const emailVerified = payload.email_verified === true || payload.email_verified === "true";
+
+  const userId = await resolveUser(env, { sub, email, emailVerified, name: payload.name });
+  if (!userId) {
+    // Email collision with an existing password account, but Google has not
+    // verified the email — refuse to link (account-takeover guard).
+    return error("Email is not verified by Google; cannot link to existing account", 403);
+  }
+
+  const sessionId = await createSession(env, userId);
+  const maxAge = Math.floor(SESSION_DURATION_MS / 1000);
+  const location = new URL("/dashboard", request.url).toString();
+
+  const headers = new Headers();
+  headers.append("Location", location);
+  headers.append("Set-Cookie", setSessionCookie(sessionId, maxAge));
+  headers.append("Set-Cookie", clearStateCookie());
+
+  return new Response(null, { status: 302, headers });
+}
+
+interface ResolveInput {
+  sub: string;
+  email: string;
+  emailVerified: boolean;
+  name?: string;
+}
+
+// Resolve the local user for a Google identity, creating or linking as needed.
+// Returns the user id, or null when linking is refused (unverified email).
+async function resolveUser(env: Env, input: ResolveInput): Promise<string | null> {
+  const { sub, email, emailVerified, name } = input;
+
+  // 1. Existing oauth link by Google `sub` → log in.
+  const existingLink = await env.DB.prepare(
+    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
+  )
+    .bind(PROVIDER, sub)
+    .first<{ user_id: string }>();
+
+  if (existingLink) {
+    return existingLink.user_id;
+  }
+
+  // 2. Existing user by email → link only when Google has verified the email.
+  const existingUser = await env.DB.prepare("SELECT id FROM users WHERE email = ?")
+    .bind(email)
+    .first<{ id: string }>();
+
+  if (existingUser) {
+    if (!emailVerified) {
+      return null;
+    }
+    await linkOAuthAccount(env, existingUser.id, sub);
+    return existingUser.id;
+  }
+
+  // 3. No match → create a new (passwordless) user and link the identity.
+  const newUserId = crypto.randomUUID();
+  const displayName = name?.trim() || email.split("@")[0];
+
+  await env.DB.prepare("INSERT INTO users (id, email, name, password_hash) VALUES (?, ?, ?, NULL)")
+    .bind(newUserId, email, displayName)
+    .run();
+
+  await linkOAuthAccount(env, newUserId, sub);
+  return newUserId;
+}
+
+async function linkOAuthAccount(env: Env, userId: string, sub: string): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO oauth_accounts (user_id, provider, provider_user_id) VALUES (?, ?, ?)",
+  )
+    .bind(userId, PROVIDER, sub)
+    .run();
+}

--- a/functions/lib/shared.ts
+++ b/functions/lib/shared.ts
@@ -2,6 +2,10 @@
 export const SESSION_COOKIE_NAME = "draftwell-session";
 export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+// OAuth state (CSRF) cookie configuration
+export const OAUTH_STATE_COOKIE_NAME = "draftwell-oauth-state";
+export const OAUTH_STATE_DURATION_S = 10 * 60; // 10 minutes
+
 // Simple response helpers
 export function json(data: unknown, status = 200, headers: Record<string, string> = {}) {
   return new Response(JSON.stringify(data), {
@@ -24,6 +28,24 @@ export function clearSessionCookie(): string {
 }
 
 export function getSessionIdFromCookie(request: Request): string | null {
+  return getCookie(request, SESSION_COOKIE_NAME);
+}
+
+// OAuth state cookie helpers. SameSite=Lax (not Strict) so the cookie is sent on
+// the top-level GET navigation back from Google to the callback endpoint.
+export function setStateCookie(state: string): string {
+  return `${OAUTH_STATE_COOKIE_NAME}=${state}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${OAUTH_STATE_DURATION_S}`;
+}
+
+export function clearStateCookie(): string {
+  return `${OAUTH_STATE_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+}
+
+export function getStateFromCookie(request: Request): string | null {
+  return getCookie(request, OAUTH_STATE_COOKIE_NAME);
+}
+
+function getCookie(request: Request, name: string): string | null {
   const cookieHeader = request.headers.get("Cookie") || "";
   const cookies = Object.fromEntries(
     cookieHeader.split(";").map((c) => {
@@ -31,5 +53,5 @@ export function getSessionIdFromCookie(request: Request): string | null {
       return [key, val.join("=")];
     }),
   );
-  return cookies[SESSION_COOKIE_NAME] || null;
+  return cookies[name] || null;
 }

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -7,6 +7,11 @@ export interface Env {
   ANTHROPIC_API_KEY: string;
   AI_GATEWAY: string;
   AI_GATEWAY_TOKEN: string;
+  // Google OAuth (optional — set via `wrangler secret put`). When unset, the
+  // Google sign-in endpoints degrade gracefully instead of redirecting with an
+  // empty client id.
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
 }
 
 export interface VoiceProfile {

--- a/migrations/0003_google_oauth.sql
+++ b/migrations/0003_google_oauth.sql
@@ -1,0 +1,44 @@
+-- Google OAuth support
+-- 1. Relax users.password_hash to nullable so Google-only accounts (which have
+--    no password) can be stored. SQLite cannot drop a NOT NULL constraint via
+--    ALTER TABLE, so the users table is recreated and its rows copied over.
+-- 2. Add an oauth_accounts table linking a provider identity (e.g. Google `sub`)
+--    to a local user, so one user can carry multiple identities.
+--
+-- Migration ordering note: D1 applies migrations in lexicographic filename
+-- order, so this 0003_ file runs after both 0002_ files (0002_score_tracking.sql,
+-- 0002_voice_profiles.sql).
+
+-- Recreate users with a nullable password_hash.
+CREATE TABLE users_new (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT,
+  name TEXT NOT NULL,
+  verified INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+INSERT INTO users_new (id, email, password_hash, name, verified, created_at, updated_at)
+SELECT id, email, password_hash, name, verified, created_at, updated_at FROM users;
+
+DROP TABLE users;
+
+ALTER TABLE users_new RENAME TO users;
+
+-- Recreate the email index dropped along with the old users table.
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+-- Provider identity links. PRIMARY KEY (provider, provider_user_id) enforces
+-- that a given Google account maps to at most one local user.
+CREATE TABLE IF NOT EXISTS oauth_accounts (
+  user_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  provider_user_id TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (provider, provider_user_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_accounts_user_id ON oauth_accounts(user_id);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -23,6 +23,8 @@ export function LoginPage() {
   const { login, register } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const oauthError = searchParams.get("error") === "oauth";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,6 +63,14 @@ export function LoginPage() {
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
+            {oauthError && (
+              <div
+                role="alert"
+                className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                Google sign-in failed. Please try again or use email and password.
+              </div>
+            )}
             {!isLogin && (
               <div className="space-y-2">
                 <label htmlFor="name" className="text-sm font-medium">
@@ -106,6 +116,15 @@ export function LoginPage() {
           <CardFooter className="flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isSubmitting}>
               {isSubmitting ? "Loading..." : isLogin ? "Sign In" : "Create Account"}
+            </Button>
+            <div className="flex w-full items-center gap-3">
+              <span className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">or</span>
+              <span className="h-px flex-1 bg-border" />
+            </div>
+            {/* Redirect-based OAuth flow: full-page navigation, not a fetch. */}
+            <Button asChild variant="outline" className="w-full">
+              <a href="/api/auth/google">Sign in with Google</a>
             </Button>
             <Button
               type="button"

--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -112,6 +112,43 @@ describe("LoginPage", () => {
     expect(screen.getByLabelText(/name/i)).toBeRequired();
   });
 
+  it("shows the Google sign-in button in login mode", () => {
+    renderWithProviders(<LoginPage />);
+
+    const googleButton = screen.getByRole("link", { name: /sign in with google/i });
+    expect(googleButton).toBeInTheDocument();
+    expect(googleButton).toHaveAttribute("href", "/api/auth/google");
+  });
+
+  it("shows the Google sign-in button in registration mode", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LoginPage />);
+
+    await user.click(screen.getByRole("button", { name: /don't have an account/i }));
+
+    const googleButton = screen.getByRole("link", { name: /sign in with google/i });
+    expect(googleButton).toBeInTheDocument();
+    expect(googleButton).toHaveAttribute("href", "/api/auth/google");
+  });
+
+  it("renders an error message when ?error=oauth is present", () => {
+    window.history.pushState({}, "", "/login?error=oauth");
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/google sign-in failed/i);
+
+    // Reset the URL so it doesn't leak into other tests.
+    window.history.pushState({}, "", "/");
+  });
+
+  it("does not render the oauth error message without the query param", () => {
+    window.history.pushState({}, "", "/login");
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    window.history.pushState({}, "", "/");
+  });
+
   it("submits registration form with valid data", async () => {
     const user = userEvent.setup();
     renderWithProviders(<LoginPage />);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,6 +28,14 @@ binding = "AI"
 # Create at: dash.cloudflare.com → AI → AI Gateway → "draftwell"
 
 # Environment variables (add secrets via `wrangler secret put`)
+#
+# Google OAuth (required for "Sign in with Google"; the endpoints degrade
+# gracefully with a 503 when unset):
+#   wrangler secret put GOOGLE_CLIENT_ID
+#   wrangler secret put GOOGLE_CLIENT_SECRET
+# Create a Google Cloud OAuth 2.0 "Web application" client and register the
+# authorized redirect URI: https://draftwell.org/api/auth/google/callback
+# (add http://localhost:8788/api/auth/google/callback for local dev).
 [vars]
 APP_NAME = "Draftwell"
 AI_GATEWAY = "251e6e8626d921603fdc3f0d75576bc6/draftwell"


### PR DESCRIPTION
## Summary

Adds a redirect-based Google OAuth 2.0 (authorization-code grant) sign-in option alongside the existing email/password auth. First Google sign-in creates a passwordless account; repeat sign-ins match by Google `sub`; an existing email account is linked only when Google reports `email_verified: true`. Sessions reuse the existing cookie-based mechanism, so expiry/refresh/logout behave identically to password login.

## Changes

- **`migrations/0003_google_oauth.sql`** (new): relaxes `users.password_hash` to nullable via SQLite recreate-and-copy (recreating the `idx_users_email` index), and adds an `oauth_accounts` table with `PRIMARY KEY (provider, provider_user_id)` and an `ON DELETE CASCADE` FK to `users`.
- **`functions/lib/google-auth.ts`** (new):
  - `GET /api/auth/google` — generates random `state`, sets a short-lived `SameSite=Lax` HttpOnly cookie, 302s to Google's auth endpoint (scopes `openid email profile`). Returns **503** when secrets are unset (no broken redirect).
  - `GET /api/auth/google/callback` — enforces state match (mismatch → **400**), exchanges the code at `https://oauth2.googleapis.com/token`, validates `aud` == client id and `iss`, then resolves the account: (1) existing `sub` link → log in; (2) existing email → link only if `email_verified` (else **403**); (3) otherwise create a passwordless user (name falls back to the email local-part). Establishes a session and 302s to `/dashboard`. User-denied consent / token failures → `/login?error=oauth`.
- **`functions/lib/auth.ts`**: `handleLogin` returns **401** (not 500) for a null-`password_hash` account; `createSession` exported for reuse.
- **`functions/lib/shared.ts`**: `SameSite=Lax` OAuth state-cookie helpers (Lax so the cookie survives the top-level redirect back from Google).
- **`functions/lib/types.ts`**: optional `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` on `Env`.
- **`src/pages/LoginPage.tsx`**: "Sign in with Google" button (full-page navigation to `/api/auth/google`, not a fetch) shown in both login and register modes; `?error=oauth` renders an alert.
- **`wrangler.toml`**: comment documenting the two new secrets and redirect URI.
- **Tests**: `functions/lib/__tests__/google-auth.test.ts` (mocked D1 + mocked Google token endpoint) and additional `src/pages/__tests__/LoginPage.test.tsx` cases.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Google button in both login and register modes | ✅ | LoginPage tests assert the `link` with `href="/api/auth/google"` in both modes |
| First sign-in creates passwordless user + session | ✅ | Test: no link/no email match → 1 user insert (password_hash NULL), 1 link, 1 session, 302 → /dashboard |
| Repeat sign-in matches by Google `sub` (not email) | ✅ | Test: existing `oauth_accounts` link → session for that user id, no new user/link |
| Email-link only when `email_verified: true` | ✅ | Tests: verified → links to existing user; unverified → 403, no link, no session |
| `state` generated, cookie-stored, enforced (mismatch → 400) | ✅ | Auth test asserts state cookie set; callback tests: mismatch → 400, missing cookie → 400 |
| Session behavior identical to password login | ✅ | Reuses `createSession` + `setSessionCookie` (same `draftwell-session` cookie/duration) |
| Password login on Google-only account → 401 (not 500) | ✅ | `handleLogin` guard test asserts 401 for null `password_hash` |
| Missing secrets → graceful error, not broken redirect | ✅ | Tests: `/api/auth/google` and callback return 503 when unconfigured |
| Existing email/password flows unchanged | ✅ | Full suite green (133 tests); auth handlers otherwise untouched |

## Test Plan

- `npm run check:ci` (tsc + biome + vitest) passes: **133 tests, exit 0**.
- Backend (Vitest, mocked D1 + mocked token endpoint): new-user creation, repeat-`sub` login, verified email link, unverified 403, state mismatch 400, missing state 400, aud/iss rejection, name fallback, unconfigured 503, null-password login 401.
- Frontend (Vitest): Google button renders in both modes with correct href; `?error=oauth` renders the alert.
- **Not attempted** (out of scope, requires operator-provisioned live credentials): manual round-trip against a real Google OAuth client on a preview deploy.

## Notes

- **Migration ordering**: D1 applies migrations lexicographically, so `0003_google_oauth.sql` runs after both existing `0002_` files (`0002_score_tracking.sql`, `0002_voice_profiles.sql`). Verified the filename sorts last.
- **Deployment prerequisite (operator)**: a Google Cloud OAuth 2.0 web client plus `wrangler secret put GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are required in production; code/tests do not depend on live credentials.
- Pre-existing: biome reports one *info* diagnostic about a config `$schema` version (2.4.11 vs 2.4.12) unrelated to this change; `check:ci` still exits 0.

Closes #74